### PR TITLE
CMake fetch standard

### DIFF
--- a/.github/jobs/ios.yml
+++ b/.github/jobs/ios.yml
@@ -27,7 +27,7 @@ jobs:
       echo Boot iOS Simulator
       xcrun simctl boot "iPhone 11"
       echo Install UnitTests app
-      xcrun simctl install booted "Build/iOS/Tests/UnitTests/Debug-iphonesimulator/UnitTests.app"
+      xcrun simctl install booted "Build/iOS/Tests/UnitTests/Debug/UnitTests.app"
       echo Launch UnitTests app
       xcrun simctl launch --console booted "com.jsruntimehost.unittests" 2> /tmp/exitCode
       (exit $(cat /tmp/exitCode))

--- a/.github/jobs/ios.yml
+++ b/.github/jobs/ios.yml
@@ -27,7 +27,7 @@ jobs:
       echo Boot iOS Simulator
       xcrun simctl boot "iPhone 11"
       echo Install UnitTests app
-      xcrun simctl install booted "Build/iOS/Tests/UnitTests/Debug/UnitTests.app"
+      xcrun simctl install booted "Build/iOS/Tests/UnitTests/Debug-iphonesimulator/UnitTests.app"
       echo Launch UnitTests app
       xcrun simctl launch --console booted "com.jsruntimehost.unittests" 2> /tmp/exitCode
       (exit $(cat /tmp/exitCode))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,10 @@ FetchContent_Declare(llhttp
 set(CONTENT_TO_FETCH cmake-extensions)
 
 if(IOS)
-    set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} ios-cmake)
+    FetchContent_MakeAvailable(ios-cmake)
+    set(CMAKE_TOOLCHAIN_FILE "${ios-cmake_SOURCE_DIR}/ios.toolchain.cmake" CACHE PATH "")
+    set(PLATFORM "OS64COMBINED" CACHE STRING "")
+    set(DEPLOYMENT_TARGET "12" CACHE STRING "")
 endif()
 
 # Project
@@ -95,12 +98,6 @@ endif()
 
 if(NOT TARGET UrlLib AND JSRUNTIMEHOST_POLYFILL_XMLHTTPREQUEST)
     set_property(TARGET UrlLib PROPERTY FOLDER Dependencies)
-endif()
-
-if(IOS)
-    set(CMAKE_TOOLCHAIN_FILE "${ios-cmake_SOURCE_DIR}/ios.toolchain.cmake" CACHE PATH "")
-    set(PLATFORM "OS64COMBINED" CACHE STRING "")
-    set(DEPLOYMENT_TARGET "12" CACHE STRING "")
 endif()
 
 if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ FetchContent_Declare(arcana
     GIT_TAG 10d167ffe0f86b2ddaccd93fd78ff2240cbb0c49)
 FetchContent_Declare(UrlLib
     GIT_REPOSITORY https://github.com/BabylonJS/UrlLib.git
-    GIT_TAG e1c9e9670cf899c1dcef359b1aba14b1b6a78f4d)
+    GIT_TAG 7a48d1b5a036cbf6c6fddb03aca3aee58484ec9c)
 FetchContent_Declare(asio
     GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
     GIT_TAG f693a3eb7fe72a5f19b975289afc4f437d373d9c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,9 @@ if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INS
 endif()
 
 # Fetching content
-message(STATUS "Fetching ${CONTENT_TO_FETCH}")
+message(STATUS "Fetching for ${CMAKE_PROJECT_NAME} : ${CONTENT_TO_FETCH}")
 FetchContent_MakeAvailable(${CONTENT_TO_FETCH})
-message(STATUS "Fetching ${CONTENT_TO_FETCH} - done")
+message(STATUS "${CMAKE_PROJECT_NAME} content fetched.")
 
 # Set properties after fetching content
 if(NOT TARGET arcana)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,28 +5,31 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)
 endif()
 
-# fetch necessary modules
-
 include(FetchContent)
 
-# CMakeExtensions
-include(FetchContent)
-message(STATUS "Fetching CMakeExtensions")
+# Modules declaration
 FetchContent_Declare(cmake-extensions
     GIT_REPOSITORY https://github.com/BabylonJS/CMakeExtensions.git
     GIT_TAG 7bdd0664181ce3d90dc94474464cea9b25b22db7)
-FetchContent_MakeAvailable(cmake-extensions)
-message(STATUS "Fetching CMakeExtensions - done")
+FetchContent_Declare(ios-cmake
+    GIT_REPOSITORY https://github.com/leetal/ios-cmake.git
+    GIT_TAG 04d91f6675dabb3c97df346a32f6184b0a7ef845)
+FetchContent_Declare(arcana
+    GIT_REPOSITORY https://github.com/microsoft/arcana.cpp.git
+    GIT_TAG 10d167ffe0f86b2ddaccd93fd78ff2240cbb0c49)
+FetchContent_Declare(UrlLib
+    GIT_REPOSITORY https://github.com/BabylonJS/UrlLib.git
+    GIT_TAG 4182996cbe3b85a960e38bd8a61892688ed55213)
+FetchContent_Declare(asio
+    GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
+    GIT_TAG f693a3eb7fe72a5f19b975289afc4f437d373d9c)
+FetchContent_Declare(llhttp
+    URL "https://github.com/nodejs/llhttp/archive/refs/tags/release/v8.1.0.tar.gz")
+
+set(CONTENT_TO_FETCH cmake-extensions)
 
 if(IOS)
-    FetchContent_Declare(ios-cmake
-        GIT_REPOSITORY https://github.com/leetal/ios-cmake.git
-        GIT_TAG 04d91f6675dabb3c97df346a32f6184b0a7ef845)
-
-    message(STATUS "Fetching ios-cmake")
-    FetchContent_MakeAvailable(ios-cmake)
-    message(STATUS "Fetching ios-cmake - done")
-
+    set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} ios-cmake)
     set(CMAKE_TOOLCHAIN_FILE "${ios-cmake_SOURCE_DIR}/ios.toolchain.cmake" CACHE PATH "")
     set(PLATFORM "OS64COMBINED" CACHE STRING "")
     set(DEPLOYMENT_TARGET "12" CACHE STRING "")
@@ -63,39 +66,20 @@ option(NAPI_BUILD_ABI "Build the ABI layer." ON)
 # Dependencies
 
 if(NOT TARGET arcana)
-    FetchContent_Declare(arcana
-        GIT_REPOSITORY https://github.com/microsoft/arcana.cpp.git
-        GIT_TAG 10d167ffe0f86b2ddaccd93fd78ff2240cbb0c49)
-
-    message(STATUS "Fetching arcana.cpp")
-    FetchContent_MakeAvailable(arcana)
-    message(STATUS "Fetching arcana.cpp - done")
+    set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} arcana)
 
     set_property(TARGET arcana PROPERTY FOLDER Dependencies)
 endif()
 
 if(NOT TARGET UrlLib AND JSRUNTIMEHOST_POLYFILL_XMLHTTPREQUEST)
-    FetchContent_Declare(
-        UrlLib
-        GIT_REPOSITORY https://github.com/BabylonJS/UrlLib.git
-        GIT_TAG 4182996cbe3b85a960e38bd8a61892688ed55213)
-
-    message(STATUS "Fetching UrlLib")
-    FetchContent_MakeAvailable(UrlLib)
-    message(STATUS "Fetching UrlLib - done")
+    set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} UrlLib)
 
     set_property(TARGET UrlLib PROPERTY FOLDER Dependencies)
 endif()
 
 if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR)
     if(NOT TARGET asio)
-        FetchContent_Declare(asio
-            GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
-            GIT_TAG f693a3eb7fe72a5f19b975289afc4f437d373d9c)
-
-        message(STATUS "Fetching asio")
-        FetchContent_MakeAvailable(asio)
-        message(STATUS "Fetching asio - done")
+        set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} asio)
 
         add_library(asio INTERFACE)
         target_include_directories(asio INTERFACE "${asio_SOURCE_DIR}/asio/include")
@@ -104,14 +88,9 @@ if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INS
     endif()
 
     if(NOT TARGET llhttp_static)
-        FetchContent_Declare(llhttp
-            URL "https://github.com/nodejs/llhttp/archive/refs/tags/release/v8.1.0.tar.gz")
-
-        message(STATUS "Fetching llhttp")
         set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
         set(BUILD_STATIC_LIBS ON CACHE INTERNAL "")
-        FetchContent_MakeAvailable(llhttp)
-        message(STATUS "Fetching llhttp - done")
+        set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} llhttp)
 
         set_property(TARGET llhttp_static PROPERTY FOLDER Dependencies)
     endif()
@@ -141,3 +120,8 @@ add_subdirectory(Polyfills)
 if(JSRUNTIMEHOST_TESTS)
     add_subdirectory(Tests)
 endif()
+
+# Fetching content
+message(STATUS "Fetching ${CONTENT_TO_FETCH}")
+FetchContent_MakeAvailable(${CONTENT_TO_FETCH})
+message(STATUS "Fetching ${CONTENT_TO_FETCH} - done")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ FetchContent_Declare(arcana
     GIT_TAG 10d167ffe0f86b2ddaccd93fd78ff2240cbb0c49)
 FetchContent_Declare(UrlLib
     GIT_REPOSITORY https://github.com/BabylonJS/UrlLib.git
-    GIT_TAG 4182996cbe3b85a960e38bd8a61892688ed55213)
+    GIT_TAG e1c9e9670cf899c1dcef359b1aba14b1b6a78f4d)
 FetchContent_Declare(asio
     GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
     GIT_TAG f693a3eb7fe72a5f19b975289afc4f437d373d9c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ if(IOS)
     set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} ios-cmake)
 endif()
 
+# Project
 project(JsRuntimeHost)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,9 @@ if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INS
 endif()
 
 # Fetching content
-message(STATUS "Fetching for ${CMAKE_PROJECT_NAME} : ${CONTENT_TO_FETCH}")
+message(STATUS "Fetching dependencies for ${PROJECT_NAME} (${CONTENT_TO_FETCH})")
 FetchContent_MakeAvailable(${CONTENT_TO_FETCH})
-message(STATUS "${CMAKE_PROJECT_NAME} content fetched.")
+message(STATUS "Fetching dependencies for ${PROJECT_NAME} - done")
 
 # Set properties after fetching content
 if(NOT TARGET arcana)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,19 +73,12 @@ endif()
 if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR)
     if(NOT TARGET asio)
         set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} asio)
-
-        add_library(asio INTERFACE)
-        target_include_directories(asio INTERFACE "${asio_SOURCE_DIR}/asio/include")
-
-        set_property(TARGET asio PROPERTY FOLDER Dependencies)
     endif()
 
     if(NOT TARGET llhttp_static)
         set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
         set(BUILD_STATIC_LIBS ON CACHE INTERNAL "")
         set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} llhttp)
-
-        set_property(TARGET llhttp_static PROPERTY FOLDER Dependencies)
     endif()
 endif()
 
@@ -107,6 +100,17 @@ if(IOS)
     set(CMAKE_TOOLCHAIN_FILE "${ios-cmake_SOURCE_DIR}/ios.toolchain.cmake" CACHE PATH "")
     set(PLATFORM "OS64COMBINED" CACHE STRING "")
     set(DEPLOYMENT_TARGET "12" CACHE STRING "")
+endif()
+
+if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR)
+    if(NOT TARGET asio)
+        add_library(asio INTERFACE)
+        target_include_directories(asio INTERFACE "${asio_SOURCE_DIR}/asio/include")
+        set_property(TARGET asio PROPERTY FOLDER Dependencies)
+    endif()
+    if(NOT TARGET llhttp_static)
+        set_property(TARGET llhttp_static PROPERTY FOLDER Dependencies)
+    endif()
 endif()
 
 # Subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,14 +67,10 @@ option(NAPI_BUILD_ABI "Build the ABI layer." ON)
 
 if(NOT TARGET arcana)
     set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} arcana)
-
-    set_property(TARGET arcana PROPERTY FOLDER Dependencies)
 endif()
 
 if(NOT TARGET UrlLib AND JSRUNTIMEHOST_POLYFILL_XMLHTTPREQUEST)
     set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} UrlLib)
-
-    set_property(TARGET UrlLib PROPERTY FOLDER Dependencies)
 endif()
 
 if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR)
@@ -94,6 +90,20 @@ if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INS
 
         set_property(TARGET llhttp_static PROPERTY FOLDER Dependencies)
     endif()
+endif()
+
+# Fetching content
+message(STATUS "Fetching ${CONTENT_TO_FETCH}")
+FetchContent_MakeAvailable(${CONTENT_TO_FETCH})
+message(STATUS "Fetching ${CONTENT_TO_FETCH} - done")
+
+# Set properties after fetching content
+if(NOT TARGET arcana)
+    set_property(TARGET arcana PROPERTY FOLDER Dependencies)
+endif()
+
+if(NOT TARGET UrlLib AND JSRUNTIMEHOST_POLYFILL_XMLHTTPREQUEST)
+    set_property(TARGET UrlLib PROPERTY FOLDER Dependencies)
 endif()
 
 # Subdirectories
@@ -120,8 +130,3 @@ add_subdirectory(Polyfills)
 if(JSRUNTIMEHOST_TESTS)
     add_subdirectory(Tests)
 endif()
-
-# Fetching content
-message(STATUS "Fetching ${CONTENT_TO_FETCH}")
-FetchContent_MakeAvailable(${CONTENT_TO_FETCH})
-message(STATUS "Fetching ${CONTENT_TO_FETCH} - done")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,6 @@ set(CONTENT_TO_FETCH cmake-extensions)
 
 if(IOS)
     set(CONTENT_TO_FETCH ${CONTENT_TO_FETCH} ios-cmake)
-    set(CMAKE_TOOLCHAIN_FILE "${ios-cmake_SOURCE_DIR}/ios.toolchain.cmake" CACHE PATH "")
-    set(PLATFORM "OS64COMBINED" CACHE STRING "")
-    set(DEPLOYMENT_TARGET "12" CACHE STRING "")
 endif()
 
 project(JsRuntimeHost)
@@ -104,6 +101,12 @@ endif()
 
 if(NOT TARGET UrlLib AND JSRUNTIMEHOST_POLYFILL_XMLHTTPREQUEST)
     set_property(TARGET UrlLib PROPERTY FOLDER Dependencies)
+endif()
+
+if(IOS)
+    set(CMAKE_TOOLCHAIN_FILE "${ios-cmake_SOURCE_DIR}/ios.toolchain.cmake" CACHE PATH "")
+    set(PLATFORM "OS64COMBINED" CACHE STRING "")
+    set(DEPLOYMENT_TARGET "12" CACHE STRING "")
 endif()
 
 # Subdirectories


### PR DESCRIPTION
Doing this PR as a test so we are on the same page. I'll do the same work for BN and others once we settle down with this 'standard'.

- moved every `FetchContent_Declare` at the top of the file
- added `CONTENT_TO_FETCH` variable to hold content to really fetch
- a fetch for ios toolchain is separated. It doesn't look possible to fetch the toolchain at the same place. I guess it's too late in CMake pipeline
- set `TARGET` properties after fetch for obvious reason. This means some tests are duplicated. IDK if it's possible to improve that (like `if(NOT TARGET UrlLib AND JSRUNTIMEHOST_POLYFILL_XMLHTTPREQUEST)`)