### PR TITLE
Mocha Premade reporter

### DIFF
--- a/Tests/UnitTests/Scripts/tests.js
+++ b/Tests/UnitTests/Scripts/tests.js
@@ -1,24 +1,7 @@
 ﻿// Set this to true to make attaching a debugging easier.
 const waitForDebugger = false;
 
-// TODO: use premade reporter (once Console Polyfill is fixed)
-function BabylonReporter(runner) {
-    const stats = runner.stats;
-
-    runner.on("pass", test => {
-        console.log(`Passed: ${test.fullTitle()}`);
-    });
-
-    runner.on("fail", (test, err) => {
-        console.log(`Failed: ${test.fullTitle()} with error: ${err.message}`);
-    });
-
-    runner.on("end", () => {
-        console.log(`Tests passed: ${stats.passes}/${stats.tests}`);
-    });
-}
-
-mocha.setup({ ui: "bdd", reporter: BabylonReporter });
+mocha.setup({ ui: "bdd", reporter: "list" });
 
 const expect = chai.expect;
 

--- a/Tests/UnitTests/Scripts/tests.js
+++ b/Tests/UnitTests/Scripts/tests.js
@@ -1,7 +1,7 @@
 ﻿// Set this to true to make attaching a debugging easier.
 const waitForDebugger = false;
 
-mocha.setup({ ui: "bdd", reporter: "list" });
+mocha.setup({ ui: "bdd", reporter: "list", color: true });
 
 const expect = chai.expect;
 

--- a/Tests/UnitTests/Scripts/tests.js
+++ b/Tests/UnitTests/Scripts/tests.js
@@ -1,7 +1,7 @@
 ﻿// Set this to true to make attaching a debugging easier.
 const waitForDebugger = false;
 
-mocha.setup({ ui: "bdd", reporter: "list", color: true });
+mocha.setup({ ui: "bdd", reporter: "tap", retries: 5 });
 
 const expect = chai.expect;
 


### PR DESCRIPTION
fixes https://github.com/BabylonJS/BabylonNative/issues/894
Using `Tap` for simple and efficient log. No issue with current console implementation.
Set retries to 5 instead of 1