### PR TITLE
Fix unittests

### DIFF
--- a/.github/jobs/win32.yml
+++ b/.github/jobs/win32.yml
@@ -31,6 +31,10 @@ jobs:
       reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\UnitTests.exe" /v DumpFolder /t REG_SZ /d "$(Build.ArtifactStagingDirectory)/Dumps"
     displayName: 'Enable Crash Dumps'
 
+  - script: UnitTests.exe
+    workingDirectory: 'Build/Win32/Tests/UnitTests/Debug'
+    displayName: 'Run Tests'
+
   - task: CopyFiles@2
     inputs:
       sourceFolder: 'Build/Win32/Tests/UnitTests/Debug'
@@ -46,7 +50,3 @@ jobs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)/Dumps'
     displayName: 'Publish Tests Dumps'
     condition: failed()
-
-  - script: UnitTests.exe
-    workingDirectory: 'Build/Win32/Tests/UnitTests/Debug'
-    displayName: 'Run Tests'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ FetchContent_Declare(arcana
     GIT_TAG 10d167ffe0f86b2ddaccd93fd78ff2240cbb0c49)
 FetchContent_Declare(UrlLib
     GIT_REPOSITORY https://github.com/BabylonJS/UrlLib.git
-    GIT_TAG 7a48d1b5a036cbf6c6fddb03aca3aee58484ec9c)
+    GIT_TAG a78c0d7dc284b028990c2fc180ae9e22b3d80b50)
 FetchContent_Declare(asio
     GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
     GIT_TAG f693a3eb7fe72a5f19b975289afc4f437d373d9c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ FetchContent_Declare(arcana
     GIT_TAG 10d167ffe0f86b2ddaccd93fd78ff2240cbb0c49)
 FetchContent_Declare(UrlLib
     GIT_REPOSITORY https://github.com/BabylonJS/UrlLib.git
-    GIT_TAG a78c0d7dc284b028990c2fc180ae9e22b3d80b50)
+    GIT_TAG 8695549bf8949af7694aafbb082d04352d8c27d4)
 FetchContent_Declare(asio
     GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
     GIT_TAG f693a3eb7fe72a5f19b975289afc4f437d373d9c)

--- a/Polyfills/WebSocket/Source/WebSocket.cpp
+++ b/Polyfills/WebSocket/Source/WebSocket.cpp
@@ -172,10 +172,14 @@ namespace Babylon::Polyfills::Internal
     void WebSocket::OpenCallback()
     {
         m_runtimeScheduler([this, cancellationSource{m_cancellationSource}]() {
+            if (cancellationSource->cancelled())
+            {
+                return;
+            }
             m_readyState = ReadyState::Open;
             try
             {
-                if (!cancellationSource->cancelled() && !m_onopen.IsEmpty())
+                if (!m_onopen.IsEmpty())
                 {
                     m_onopen.Call({});
                 }

--- a/Polyfills/WebSocket/Source/WebSocket.cpp
+++ b/Polyfills/WebSocket/Source/WebSocket.cpp
@@ -41,8 +41,14 @@ namespace Babylon::Polyfills::Internal
               [this](const std::string& message) { MessageCallback(message); },
               [this](const std::string& message) { ErrorCallback(message); })
         , m_url(info[0].As<Napi::String>())
+        , m_cancellationSource{std::make_shared<arcana::cancellation_source>()}
     {
         m_webSocket.Open();
+    }
+
+    WebSocket::~WebSocket()
+    {
+        m_cancellationSource->cancel();
     }
 
     void WebSocket::Close(const Napi::CallbackInfo& info)
@@ -165,11 +171,11 @@ namespace Babylon::Polyfills::Internal
 
     void WebSocket::OpenCallback()
     {
-        m_runtimeScheduler([this]() {
+        m_runtimeScheduler([this, cancellationSource{m_cancellationSource}]() {
             m_readyState = ReadyState::Open;
             try
             {
-                if (!m_onopen.IsEmpty())
+                if (!cancellationSource->cancelled() && !m_onopen.IsEmpty())
                 {
                     m_onopen.Call({});
                 }
@@ -184,7 +190,11 @@ namespace Babylon::Polyfills::Internal
 
     void WebSocket::CloseCallback(int code, const std::string& reason)
     {
-        m_runtimeScheduler([this, code, reason]() {
+        m_runtimeScheduler([this, code, reason, cancellationSource{m_cancellationSource}]() {
+            if (cancellationSource->cancelled())
+            {
+                return;
+            }
             m_readyState = ReadyState::Closed;
             try
             {
@@ -211,14 +221,17 @@ namespace Babylon::Polyfills::Internal
 
     void WebSocket::MessageCallback(const std::string& message)
     {
-        m_runtimeScheduler([this, message]() {
+        m_runtimeScheduler([this, message, cancellationSource{m_cancellationSource}]() {
             try
             {
                 if (!m_onmessage.IsEmpty())
                 {
                     Napi::Object messageEvent = Napi::Object::New(Env());
                     messageEvent.Set("data", message);
-                    m_onmessage.Call({messageEvent});
+                    if (!cancellationSource->cancelled())
+                    {
+                        m_onmessage.Call({messageEvent});
+                    }
                 }
             }
             catch (...)
@@ -231,14 +244,17 @@ namespace Babylon::Polyfills::Internal
 
     void WebSocket::ErrorCallback(const std::string& message)
     {
-        m_runtimeScheduler([this, message]() {
+        m_runtimeScheduler([this, message, cancellationSource{m_cancellationSource}]() {
             try
             {
                 if (!m_onerror.IsEmpty())
                 {
                     Napi::Object errorEvent = Napi::Object::New(Env());
                     errorEvent.Set("message", message);
-                    m_onerror.Call({errorEvent});
+                    if (!cancellationSource->cancelled())
+                    {
+                        m_onerror.Call({errorEvent});
+                    }
                 }
             }
             catch (...)

--- a/Polyfills/WebSocket/Source/WebSocket.cpp
+++ b/Polyfills/WebSocket/Source/WebSocket.cpp
@@ -226,6 +226,10 @@ namespace Babylon::Polyfills::Internal
     void WebSocket::MessageCallback(const std::string& message)
     {
         m_runtimeScheduler([this, message, cancellationSource{m_cancellationSource}]() {
+            if (cancellationSource->cancelled())
+            {
+                return;
+            }
             try
             {
                 if (!m_onmessage.IsEmpty())
@@ -249,6 +253,10 @@ namespace Babylon::Polyfills::Internal
     void WebSocket::ErrorCallback(const std::string& message)
     {
         m_runtimeScheduler([this, message, cancellationSource{m_cancellationSource}]() {
+            if (cancellationSource->cancelled())
+            {
+                return;
+            }
             try
             {
                 if (!m_onerror.IsEmpty())

--- a/Polyfills/WebSocket/Source/WebSocket.h
+++ b/Polyfills/WebSocket/Source/WebSocket.h
@@ -11,6 +11,7 @@ namespace Babylon::Polyfills::Internal
     public:
         static void Initialize(Napi::Env env);
         explicit WebSocket(const Napi::CallbackInfo& info);
+        virtual ~WebSocket();
 
     private:
         enum class ReadyState
@@ -52,5 +53,7 @@ namespace Babylon::Polyfills::Internal
         UrlLib::WebSocket m_webSocket;
         const std::string m_url{};
         ReadyState m_readyState{ReadyState::Connecting};
+
+        std::shared_ptr<arcana::cancellation_source> m_cancellationSource{};
     };
 }

--- a/Polyfills/WebSocket/Source/WebSocket.h
+++ b/Polyfills/WebSocket/Source/WebSocket.h
@@ -11,7 +11,6 @@ namespace Babylon::Polyfills::Internal
     public:
         static void Initialize(Napi::Env env);
         explicit WebSocket(const Napi::CallbackInfo& info);
-        virtual ~WebSocket();
 
     private:
         enum class ReadyState
@@ -53,7 +52,5 @@ namespace Babylon::Polyfills::Internal
         UrlLib::WebSocket m_webSocket;
         const std::string m_url{};
         ReadyState m_readyState{ReadyState::Connecting};
-
-        std::shared_ptr<arcana::cancellation_source> m_cancellationSource{};
     };
 }

--- a/Tests/UnitTests/Scripts/tests.js
+++ b/Tests/UnitTests/Scripts/tests.js
@@ -1,7 +1,7 @@
 ﻿// Set this to true to make attaching a debugging easier.
 const waitForDebugger = false;
 
-mocha.setup({ ui: "bdd", reporter: "tap", retries: 5 });
+mocha.setup({ ui: "bdd", reporter: "spec", retries: 5 });
 
 const expect = chai.expect;
 
@@ -597,15 +597,13 @@ describe("URLSearchParams", function () {
 function runTests() {
     mocha.run(failures => {
         // Test program will wait for code to be set before exiting
-        setTimeout(() => {
-            if (failures > 0) {
-                // Failure
-                SetExitCode(1);
-            } else {
-                // Success
-                SetExitCode(0);
-            }
-        }, 0);
+        if (failures > 0) {
+            // Failure
+            SetExitCode(1);
+        } else {
+            // Success
+            SetExitCode(0);
+        }
     });
 }
 

--- a/Tests/UnitTests/Scripts/tests.js
+++ b/Tests/UnitTests/Scripts/tests.js
@@ -605,7 +605,7 @@ function runTests() {
                 // Success
                 SetExitCode(0);
             }
-        }, 0);
+        }, 100);
     });
 }
 

--- a/Tests/UnitTests/Scripts/tests.js
+++ b/Tests/UnitTests/Scripts/tests.js
@@ -605,7 +605,7 @@ function runTests() {
                 // Success
                 SetExitCode(0);
             }
-        }, 1000);
+        }, 0);
     });
 }
 

--- a/Tests/UnitTests/Scripts/tests.js
+++ b/Tests/UnitTests/Scripts/tests.js
@@ -605,7 +605,7 @@ function runTests() {
                 // Success
                 SetExitCode(0);
             }
-        }, 100);
+        }, 1000);
     });
 }
 

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -41,6 +41,8 @@ int RunTests(Babylon::Polyfills::Console::CallbackT consoleCallback)
         env.Global().Set("SetExitCode", Napi::Function::New(env, [&exitCode](const Napi::CallbackInfo& info)
         {
             Napi::Env env = info.Env();
+            // no timeout allowed after exit is asked!
+            Napi::Eval(env, "setTimeout=function(){};", "");
             exitCode.set_value(info[0].As<Napi::Number>().Int32Value());
         }, "SetExitCode"));
 

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -41,8 +41,6 @@ int RunTests(Babylon::Polyfills::Console::CallbackT consoleCallback)
         env.Global().Set("SetExitCode", Napi::Function::New(env, [&exitCode](const Napi::CallbackInfo& info)
         {
             Napi::Env env = info.Env();
-            // no timeout allowed after exit is asked!
-            Napi::Eval(env, "setTimeout=function(){};", "");
             exitCode.set_value(info[0].As<Napi::Number>().Int32Value());
         }, "SetExitCode"));
 


### PR DESCRIPTION
- reorder CI win32 job to fix the artifact publish
- Fix websocket cancellation with this related PR : https://github.com/BabylonJS/UrlLib/pull/8
- removed setimeout workaround for Mocha exitCode
- changed the reporter from tap to spec. The tap reporter makes extra calls to settimeout that cause extra async operation after setting exit code. This does not happen with spec

I kicked 5 pipeline runs and 1 Android JSC job failed because it was not able to start android emulator, so issue seams to be gone.