### PR TITLE
fix v8inspector crash at shutdown

### DIFF
--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.cpp
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.cpp
@@ -351,6 +351,7 @@ namespace Babylon
 
     void InspectorSocketServer::Stop()
     {
+        std::lock_guard<std::mutex> guard{m_mutex};
         if (state_ == ServerState::kStopped)
             return;
         CHECK_EQ(state_, ServerState::kRunning);

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.cpp
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.cpp
@@ -230,6 +230,10 @@ namespace Babylon
 
     void InspectorSocketServer::SessionTerminated(int session_id)
     {
+        if (this->state_ == ServerState::kStopped)
+        {
+            return;
+        }
         if (Session(session_id) == nullptr)
         {
             return;

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.cpp
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.cpp
@@ -195,7 +195,6 @@ namespace Babylon
         : delegate_(std::move(delegate))
         , port_(port)
         , next_session_id_(0)
-        , out_(out)
     {
         state_ = ServerState::kNew;
     }

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.cpp
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.cpp
@@ -191,7 +191,7 @@ namespace Babylon
     };
 
     InspectorSocketServer::InspectorSocketServer(
-        std::unique_ptr<InspectorAgentDelegate>&& delegate, unsigned short port, FILE* out)
+        std::unique_ptr<InspectorAgentDelegate>&& delegate, unsigned short port)
         : delegate_(std::move(delegate))
         , port_(port)
         , next_session_id_(0)

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.h
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.h
@@ -84,8 +84,6 @@ namespace Babylon
         static void SocketClosedCallback(void* callbackData_);
 
     private:
-        static void CloseServerSocket(ServerSocket*);
-
         void SendListResponse(InspectorSocket* socket, const std::string& host, SocketSession* session);
         std::string GetFrontendURL(bool is_compat, const std::string& formatted_address);
         bool TargetExists(const std::string& id);

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.h
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.h
@@ -108,6 +108,7 @@ namespace Babylon
         ServerState state_;
 
         std::map<int, std::pair<std::string, std::unique_ptr<SocketSession>>> connected_sessions_;
+        mutable std::mutex m_mutex;
     };
 
 } // namespace inspector

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.h
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.h
@@ -102,7 +102,6 @@ namespace Babylon
         std::shared_ptr<tcp_server> tcp_server_;
 
         int next_session_id_;
-        FILE* out_;
         ServerState state_;
 
         std::map<int, std::pair<std::string, std::unique_ptr<SocketSession>>> connected_sessions_;

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.h
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorSocketServer.h
@@ -50,8 +50,7 @@ namespace Babylon
     class InspectorSocketServer
     {
     public:
-        InspectorSocketServer(std::unique_ptr<InspectorAgentDelegate>&& delegate, unsigned short port,
-            FILE* out = stderr);
+        InspectorSocketServer(std::unique_ptr<InspectorAgentDelegate>&& delegate, unsigned short port);
         ~InspectorSocketServer();
 
         // Start listening on host/port

--- a/Tests/UnitTests/Win32/App.cpp
+++ b/Tests/UnitTests/Win32/App.cpp
@@ -2,12 +2,9 @@
 
 int main()
 {
-    for (int i = 0; i < 1000; i++)
+    return RunTests([](const char* message, Babylon::Polyfills::Console::LogLevel logLevel)
     {
-        RunTests([](const char* message, Babylon::Polyfills::Console::LogLevel logLevel) {
-            fprintf(stdout, "[%s] %s", EnumToString(logLevel), message);
-            fflush(stdout);
-        });
-    }
-    return 0;
+        fprintf(stdout, "[%s] %s", EnumToString(logLevel), message);
+        fflush(stdout);
+    });
 }

--- a/Tests/UnitTests/Win32/App.cpp
+++ b/Tests/UnitTests/Win32/App.cpp
@@ -2,9 +2,12 @@
 
 int main()
 {
-    return RunTests([](const char* message, Babylon::Polyfills::Console::LogLevel logLevel)
+    for (int i = 0; i < 1000; i++)
     {
-        fprintf(stdout, "[%s] %s", EnumToString(logLevel), message);
-        fflush(stdout);
-    });
+        RunTests([](const char* message, Babylon::Polyfills::Console::LogLevel logLevel) {
+            fprintf(stdout, "[%s] %s", EnumToString(logLevel), message);
+            fflush(stdout);
+        });
+    }
+    return 0;
 }


### PR DESCRIPTION
`Stop ` method is called from 2 threads. the main when app stops or by the thread itself. A mutex is added to guard concurrency. Then, when Stop is called from the main thread, unique pointer is reset just after but the thread itself is still using it. reset is removed from the main thread. Thread is responsible for creating unique pointer and deleting it.

Also removed `out_` because unused.

