### PR TITLE
Fix Android compile error

### DIFF
--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -163,7 +163,7 @@ namespace Babylon::Polyfills::Internal
             responseHeadersObject.Set(key, value);
         }
 
-        return responseHeadersObject;
+        return std::move(responseHeadersObject);
     }
 
     void XMLHttpRequest::SetRequestHeader(const Napi::CallbackInfo& info)


### PR DESCRIPTION
On Android (at least in the context of Babylon React Native), the previous code results in the following error:
```
XMLHttpRequest.cpp
local variable 'responseHeadersObject' will be copied despite being returned by name [-Werror,-Wreturn-std-move]
call 'std::move' explicitly to avoid copying
```

From some reading, it seems RVO is not in effect when the type of the returned value doesn't match the return type of the function (e.g. `Napi::Value` vs. `Napi::Object`). I tested this hypothesis by changing the code to:
```c++
        Napi::Value value = std::move(responseHeadersObject);
        return value;
```
This also fixed the error, and seems to support the RVO theory. What I don't understand is why this seems to be different in BRN (obviously there is no compile issue in BN Android). I think it must have to do with napi vs. napi-jsi, but in both cases `Napi::Object` inherits from `Napi::Value`, so the type relationships all seem the same, but maybe I'm missing something.