### PR TITLE
UWP V8 job + relwithdebuginfo

### DIFF
--- a/.github/azure-pipelines.yml
+++ b/.github/azure-pipelines.yml
@@ -49,6 +49,12 @@ jobs:
       platform: arm64
       jsEngine: JSI
 
+  - template: jobs/uwp.yml
+    parameters:
+      name: UWP_arm64_V8
+      platform: arm64
+      jsEngine: V8
+
   # Android
   - template: jobs/android.yml
     parameters:

--- a/.github/azure-pipelines.yml
+++ b/.github/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
   - template: jobs/uwp.yml
     parameters:
       name: UWP_arm64_V8
-      platform: arm64
+      platform: x64
       jsEngine: V8
 
   # Android

--- a/.github/azure-pipelines.yml
+++ b/.github/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
 
   - template: jobs/uwp.yml
     parameters:
-      name: UWP_arm64_V8
+      name: UWP_x64_V8
       platform: x64
       jsEngine: V8
 

--- a/.github/jobs/ios.yml
+++ b/.github/jobs/ios.yml
@@ -20,14 +20,14 @@ jobs:
       scheme: 'UnitTests'
       sdk: 'iphonesimulator'
       useXcpretty: false
-      configuration: Debug
+      configuration: RelWithDebInfo
     displayName: 'Build Xcode Project'
 
   - script: |
       echo Boot iOS Simulator
       xcrun simctl boot "iPhone 11"
       echo Install UnitTests app
-      xcrun simctl install booted "Build/iOS/Tests/UnitTests/Debug-iphonesimulator/UnitTests.app"
+      xcrun simctl install booted "Build/iOS/Tests/UnitTests/RelWithDebInfo-iphonesimulator/UnitTests.app"
       echo Launch UnitTests app
       xcrun simctl launch --console booted "com.jsruntimehost.unittests" 2> /tmp/exitCode
       (exit $(cat /tmp/exitCode))

--- a/.github/jobs/macos.yml
+++ b/.github/jobs/macos.yml
@@ -20,9 +20,9 @@ jobs:
       scheme: 'UnitTests'
       sdk: 'macosx'
       useXcpretty: false
-      configuration: Debug
+      configuration: RelWithDebInfo
     displayName: 'Build Xcode Project'
 
   - script: ./UnitTests
-    workingDirectory: 'Build/macOS/Tests/UnitTests/Debug'
+    workingDirectory: 'Build/macOS/Tests/UnitTests/RelWithDebInfo'
     displayName: 'Run Tests'

--- a/.github/jobs/uwp.yml
+++ b/.github/jobs/uwp.yml
@@ -21,6 +21,6 @@ jobs:
     inputs:
       solution: 'Build/UWP/JsRuntimeHost.sln'
       maximumCpuCount: true
-      configuration: 'Debug'
+      configuration: 'RelWithDebInfo'
     displayName: 'Build Solution'
 

--- a/.github/jobs/win32.yml
+++ b/.github/jobs/win32.yml
@@ -21,7 +21,7 @@ jobs:
     inputs:
       solution: 'Build/Win32/JsRuntimeHost.sln'
       maximumCpuCount: true
-      configuration: 'Debug'
+      configuration: 'RelWithDebInfo'
     displayName: 'Build Solution'
 
   - script: |
@@ -32,12 +32,12 @@ jobs:
     displayName: 'Enable Crash Dumps'
 
   - script: UnitTests.exe
-    workingDirectory: 'Build/Win32/Tests/UnitTests/Debug'
+    workingDirectory: 'Build/Win32/Tests/UnitTests/RelWithDebInfo'
     displayName: 'Run Tests'
 
   - task: CopyFiles@2
     inputs:
-      sourceFolder: 'Build/Win32/Tests/UnitTests/Debug'
+      sourceFolder: 'Build/Win32/Tests/UnitTests/RelWithDebInfo'
       contents: UnitTests.*
       targetFolder: '$(Build.ArtifactStagingDirectory)/Dumps'
       cleanTargetFolder: false

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorTCP.h
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorTCP.h
@@ -2,7 +2,9 @@
 // Licensed under the MIT license.
 // This code is based on the old node inspector implementation. See NOTICE.md for Node.js' project license details
 #pragma once
-
+#ifdef WIN32
+#include <Winsock2.h>
+#endif
 #include <asio.hpp>
 
 namespace Babylon

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorUtils.cpp
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorUtils.cpp
@@ -11,6 +11,18 @@
 #include <stdexcept>
 #include <codecvt>
 
+#ifdef _MSC_VER
+#define DISABLE_DEPRECATION_WARNINGS \
+    __pragma(warning(push))          \
+        __pragma(warning(disable : 4996))
+#define ENABLE_DEPRECATION_WARNINGS __pragma(warning(pop))
+#else
+#define DISABLE_DEPRECATION_WARNINGS \
+    _Pragma("GCC diagnostic push")   \
+        _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define ENABLE_DEPRECATION_WARNINGS _Pragma("GCC diagnostic pop")
+#endif
+
 namespace Babylon {
 namespace utils {
 
@@ -98,8 +110,10 @@ std::string utf16toUTF8(const uint16_t* utf16String, size_t utf16StringLen) noex
 
 std::basic_string<char16_t> Utf8ToUtf16(const char* utf8, size_t utf8Len)
 {
+DISABLE_DEPRECATION_WARNINGS
   std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
   return converter.from_bytes(utf8, utf8 + (utf8Len - 1));
+ENABLE_DEPRECATION_WARNINGS
 }
 
 std::string StringViewToUtf8(const v8_inspector::StringView& view)

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorUtils.h
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorUtils.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 // This code is based on the old node inspector implementation. See NOTICE.md for Node.js' project license details
 #pragma once
-
 #include <V8Inc.h>
 
 #include <string>

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorUtils.h
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorUtils.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 // This code is based on the old node inspector implementation. See NOTICE.md for Node.js' project license details
 #pragma once
+
 #include <V8Inc.h>
 
 #include <string>


### PR DESCRIPTION
- new UWP/V8 job
- fix `Error C2039: 'TerminateThread': is not a member of 'global namespace'`
- build as RelWithDebInfo instead of Debug
- hide ` Warning C4996: 'std::codecvt_utf8_utf16<char16_t,1114111,(std::codecvt_mode)0>': warning STL4017`
