### PR TITLE
Restore lost xhr registration logic

### DIFF
--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -62,35 +62,38 @@ namespace Babylon::Polyfills::Internal
     void XMLHttpRequest::Initialize(Napi::Env env)
     {
         static constexpr auto JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME = "XMLHttpRequest";
+
+        Napi::Function func = DefineClass(
+            env,
+            JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME,
+            {
+                StaticValue("UNSENT", Napi::Value::From(env, 0)),
+                StaticValue("OPENED", Napi::Value::From(env, 1)),
+                StaticValue("HEADERS_RECEIVED", Napi::Value::From(env, 2)),
+                StaticValue("LOADING", Napi::Value::From(env, 3)),
+                StaticValue("DONE", Napi::Value::From(env, 4)),
+                InstanceAccessor("readyState", &XMLHttpRequest::GetReadyState, nullptr),
+                InstanceAccessor("response", &XMLHttpRequest::GetResponse, nullptr),
+                InstanceAccessor("responseText", &XMLHttpRequest::GetResponseText, nullptr),
+                InstanceAccessor("responseType", &XMLHttpRequest::GetResponseType, &XMLHttpRequest::SetResponseType),
+                InstanceAccessor("responseURL", &XMLHttpRequest::GetResponseURL, nullptr),
+                InstanceAccessor("status", &XMLHttpRequest::GetStatus, nullptr),
+                InstanceMethod("getAllResponseHeaders", &XMLHttpRequest::GetAllResponseHeaders),
+                InstanceMethod("getResponseHeader", &XMLHttpRequest::GetResponseHeader),
+                InstanceMethod("setRequestHeader", &XMLHttpRequest::SetRequestHeader),
+                InstanceMethod("addEventListener", &XMLHttpRequest::AddEventListener),
+                InstanceMethod("removeEventListener", &XMLHttpRequest::RemoveEventListener),
+                InstanceMethod("abort", &XMLHttpRequest::Abort),
+                InstanceMethod("open", &XMLHttpRequest::Open),
+                InstanceMethod("send", &XMLHttpRequest::Send),
+            });
+
         if (env.Global().Get(JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME).IsUndefined())
         {
-            Napi::Function func = DefineClass(
-                env,
-                JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME,
-                {
-                    StaticValue("UNSENT", Napi::Value::From(env, 0)),
-                    StaticValue("OPENED", Napi::Value::From(env, 1)),
-                    StaticValue("HEADERS_RECEIVED", Napi::Value::From(env, 2)),
-                    StaticValue("LOADING", Napi::Value::From(env, 3)),
-                    StaticValue("DONE", Napi::Value::From(env, 4)),
-                    InstanceAccessor("readyState", &XMLHttpRequest::GetReadyState, nullptr),
-                    InstanceAccessor("response", &XMLHttpRequest::GetResponse, nullptr),
-                    InstanceAccessor("responseText", &XMLHttpRequest::GetResponseText, nullptr),
-                    InstanceAccessor("responseType", &XMLHttpRequest::GetResponseType, &XMLHttpRequest::SetResponseType),
-                    InstanceAccessor("responseURL", &XMLHttpRequest::GetResponseURL, nullptr),
-                    InstanceAccessor("status", &XMLHttpRequest::GetStatus, nullptr),
-                    InstanceMethod("getAllResponseHeaders", &XMLHttpRequest::GetAllResponseHeaders),
-                    InstanceMethod("getResponseHeader", &XMLHttpRequest::GetResponseHeader),
-                    InstanceMethod("setRequestHeader", &XMLHttpRequest::SetRequestHeader),
-                    InstanceMethod("addEventListener", &XMLHttpRequest::AddEventListener),
-                    InstanceMethod("removeEventListener", &XMLHttpRequest::RemoveEventListener),
-                    InstanceMethod("abort", &XMLHttpRequest::Abort),
-                    InstanceMethod("open", &XMLHttpRequest::Open),
-                    InstanceMethod("send", &XMLHttpRequest::Send),
-                });
-
             env.Global().Set(JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME, func);
         }
+
+        JsRuntime::NativeObject::GetFromJavaScript(env).Set(JS_XML_HTTP_REQUEST_CONSTRUCTOR_NAME, func);
     }
 
     XMLHttpRequest::XMLHttpRequest(const Napi::CallbackInfo& info)


### PR DESCRIPTION
`XmlHttpRequest` conditionally registers itself in the global scope, and *used to* unconditionally register itself on the `_native` object used for various things in `JsRuntime`. The latter part was lost when the code was moved from the Babylon Native repo to the JsRuntimeHost repo (see https://github.com/BabylonJS/BabylonNative/pull/1260/files#diff-f5407a45027308c4ca372c3c5ad6ee33725fb2d39936521df64bf3c5b003b9cf).

As is, Babylon.js and Babylon React Native rely on this to ensure Babylon Native's XHR is used rather than React Native's XHR (which is very slow, very memory intensive, and does not support some features like local file paths). See https://github.com/BabylonJS/Babylon.js/blob/48cf7b374a7bbee9f3bef02f2992715ed683cf98/packages/dev/core/src/Misc/webRequest.ts#L12C1-L13C45.

Since JsRuntimeHost is supposed to be independent of Babylon related code, having it work this way is probably not idea. However, this is currently breaking shipping code, so we need to restore this functionality for now and can consider an improved fix later.