### PR TITLE
Set result pointer before clearing it.

### DIFF
--- a/Core/Node-API/Source/js_native_api_javascriptcore.cc
+++ b/Core/Node-API/Source/js_native_api_javascriptcore.cc
@@ -1784,9 +1784,11 @@ napi_status napi_remove_wrap(napi_env env, napi_value js_object, void** result) 
   WrapperInfo* info{};
   CHECK_NAPI(WrapperInfo::Unwrap(env, js_object, &info));
   RETURN_STATUS_IF_FALSE(env, info != nullptr && info->Data() != nullptr, napi_invalid_arg);
-  info->Data(nullptr);
 
+  // This change ensures that the result pointer is correctly set to the wrapped data pointer before clearing it.
   *result = info->Data();
+  info->Data(nullptr);
+  
   return napi_ok;
 }
 

--- a/Core/Node-API/Source/js_native_api_javascriptcore.cc
+++ b/Core/Node-API/Source/js_native_api_javascriptcore.cc
@@ -1785,7 +1785,6 @@ napi_status napi_remove_wrap(napi_env env, napi_value js_object, void** result) 
   CHECK_NAPI(WrapperInfo::Unwrap(env, js_object, &info));
   RETURN_STATUS_IF_FALSE(env, info != nullptr && info->Data() != nullptr, napi_invalid_arg);
 
-  // This change ensures that the result pointer is correctly set to the wrapped data pointer before clearing it.
   *result = info->Data();
   info->Data(nullptr);
   


### PR DESCRIPTION
While working with babylon we encountered issue when calling 
`env.drop_wrapped` calls `napi_remove_wrap` which is implemented [here](https://github.com/BabylonJS/JsRuntimeHost/blob/397c12a0f17111715177cb59364361b21905f3de/Core/Node-API/Source/js_native_api_javascriptcore.cc#L1778) for Javascriptcore

It should set result to the wrapped data pointer, but that implementation will always set it to null.

This change ensures that the result pointer is correctly set to the wrapped data pointer before clearing it.