### PR TITLE
Add `BABYLON_API` calling convention macro for Core and Polyfills classes

### DIFF
--- a/Core/AppRuntime/Include/Babylon/AppRuntime.h
+++ b/Core/AppRuntime/Include/Babylon/AppRuntime.h
@@ -35,7 +35,7 @@ namespace Babylon
         void Dispatch(Dispatchable<void(Napi::Env)> callback);
 
         // Default unhandled exception handler that outputs the error message to the program output.
-        static void DefaultUnhandledExceptionHandler(const Napi::Error& error);
+        static void BABYLON_API DefaultUnhandledExceptionHandler(const Napi::Error& error);
 
     private:
         // These three methods are the mechanism by which platform- and JavaScript-specific

--- a/Core/AppRuntime/Source/AppRuntime_UWP.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_UWP.cpp
@@ -4,7 +4,7 @@
 
 namespace Babylon
 {
-    void AppRuntime::DefaultUnhandledExceptionHandler(const Napi::Error& error)
+    void BABYLON_API AppRuntime::DefaultUnhandledExceptionHandler(const Napi::Error& error)
     {
         std::ostringstream ss{};
         ss << "[Uncaught Error] " << error.Get("stack").As<Napi::String>().Utf8Value() << std::endl;

--- a/Core/AppRuntime/Source/AppRuntime_Win32.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_Win32.cpp
@@ -7,7 +7,7 @@
 
 namespace Babylon
 {
-    void AppRuntime::DefaultUnhandledExceptionHandler(const Napi::Error& error)
+    void BABYLON_API AppRuntime::DefaultUnhandledExceptionHandler(const Napi::Error& error)
     {
         std::ostringstream ss{};
         ss << "[Uncaught Error] " << error.Get("stack").As<Napi::String>().Utf8Value() << std::endl;

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -4,6 +4,7 @@ else()
     add_subdirectory(Node-API)
 endif()
 
+add_subdirectory(Foundation)
 add_subdirectory(JsRuntime)
 
 if(JSRUNTIMEHOST_CORE_APPRUNTIME)

--- a/Core/Foundation/CMakeLists.txt
+++ b/Core/Foundation/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(SOURCES
+    "Include/Babylon/Api.h")
+
+add_library(Foundation INTERFACE)
+
+target_include_directories(Foundation INTERFACE "Include")
+
+set_property(TARGET Foundation PROPERTY FOLDER Core)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Core/Foundation/Include/Babylon/Api.h
+++ b/Core/Foundation/Include/Babylon/Api.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifndef BABYLON_API
+#ifdef _WIN32
+#define BABYLON_API __cdecl
+#else
+#define BABYLON_API
+#endif
+#endif

--- a/Core/JsRuntime/CMakeLists.txt
+++ b/Core/JsRuntime/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(JsRuntime PRIVATE "Include/Babylon")
 target_include_directories(JsRuntime PUBLIC "Include")
 
 target_link_libraries(JsRuntime
+    PUBLIC Foundation
     PUBLIC napi
     PRIVATE arcana)
 

--- a/Core/JsRuntime/Include/Babylon/JsRuntime.h
+++ b/Core/JsRuntime/Include/Babylon/JsRuntime.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 #include <functional>
 #include <mutex>
@@ -16,7 +17,7 @@ namespace Babylon
             static constexpr auto JS_NATIVE_NAME = "_native";
 
         public:
-            static Napi::Object GetFromJavaScript(Napi::Env env)
+            static Napi::Object BABYLON_API GetFromJavaScript(Napi::Env env)
             {
                 return env.Global().Get(JS_NATIVE_NAME).As<Napi::Object>();
             }
@@ -28,16 +29,16 @@ namespace Babylon
         // Any JavaScript errors that occur will bubble up as a Napi::Error C++ exception.
         // JsRuntime expects the provided dispatch function to handle this exception,
         // such as with a try/catch and logging the exception message.
-        using DispatchFunctionT = std::function<void(std::function<void(Napi::Env)>)>;
+        using DispatchFunctionT = std::function<void BABYLON_API (std::function<void BABYLON_API (Napi::Env)>)>;
 
         // Note: It is the contract of JsRuntime that its dispatch function must be usable
         // at the moment of construction. JsRuntime cannot be built with dispatch function
         // that captures a reference to a not-yet-completed object that will be completed
         // later -- an instance of an inheriting type, for example. The dispatch function
         // must be safely callable as soon as it is passed to the JsRuntime constructor.
-        static JsRuntime& CreateForJavaScript(Napi::Env, DispatchFunctionT);
-        static JsRuntime& GetFromJavaScript(Napi::Env);
-        void Dispatch(std::function<void(Napi::Env)>);
+        static JsRuntime& BABYLON_API CreateForJavaScript(Napi::Env, DispatchFunctionT);
+        static JsRuntime& BABYLON_API GetFromJavaScript(Napi::Env);
+        void Dispatch(std::function<void BABYLON_API (Napi::Env)>);
 
     protected:
         JsRuntime(const JsRuntime&) = delete;

--- a/Core/JsRuntime/Source/JsRuntime.cpp
+++ b/Core/JsRuntime/Source/JsRuntime.cpp
@@ -25,13 +25,13 @@ namespace Babylon
         jsNative.Set(JS_RUNTIME_NAME, jsRuntime);
     }
 
-    JsRuntime& JsRuntime::CreateForJavaScript(Napi::Env env, DispatchFunctionT dispatchFunction)
+    JsRuntime& BABYLON_API JsRuntime::CreateForJavaScript(Napi::Env env, DispatchFunctionT dispatchFunction)
     {
         auto* runtime = new JsRuntime(env, std::move(dispatchFunction));
         return *runtime;
     }
 
-    JsRuntime& JsRuntime::GetFromJavaScript(Napi::Env env)
+    JsRuntime& BABYLON_API JsRuntime::GetFromJavaScript(Napi::Env env)
     {
         return *NativeObject::GetFromJavaScript(env)
                     .As<Napi::Object>()
@@ -40,7 +40,7 @@ namespace Babylon
                     .Data();
     }
 
-    void JsRuntime::Dispatch(std::function<void(Napi::Env)> function)
+    void JsRuntime::Dispatch(std::function<void BABYLON_API (Napi::Env)> function)
     {
         std::scoped_lock lock{m_mutex};
         m_dispatchFunction([function = std::move(function)](Napi::Env env) {

--- a/Core/Node-API/Include/Shared/napi/napi-inl.h
+++ b/Core/Node-API/Include/Shared/napi/napi-inl.h
@@ -33,7 +33,7 @@ namespace details {
 constexpr int napi_no_external_buffers_allowed = 22;
 
 template <typename FreeType>
-inline void default_finalizer(napi_env /*env*/, void* data, void* /*hint*/) {
+inline void NAPI_CDECL default_finalizer(napi_env /*env*/, void* data, void* /*hint*/) {
   delete static_cast<FreeType*>(data);
 }
 
@@ -105,7 +105,7 @@ inline void WrapVoidCallback(Callable callback) {
 
 template <typename Callable, typename Return>
 struct CallbackData {
-  static inline napi_value Wrapper(napi_env env, napi_callback_info info) {
+  static inline napi_value NAPI_CDECL Wrapper(napi_env env, napi_callback_info info) {
     return details::WrapCallback([&] {
       CallbackInfo callbackInfo(env, info);
       CallbackData* callbackData =
@@ -121,7 +121,7 @@ struct CallbackData {
 
 template <typename Callable>
 struct CallbackData<Callable, void> {
-  static inline napi_value Wrapper(napi_env env, napi_callback_info info) {
+  static inline napi_value NAPI_CDECL Wrapper(napi_env env, napi_callback_info info) {
     return details::WrapCallback([&] {
       CallbackInfo callbackInfo(env, info);
       CallbackData* callbackData =
@@ -179,7 +179,7 @@ napi_value TemplatedInstanceVoidCallback(napi_env env, napi_callback_info info)
 
 template <typename T, typename Finalizer, typename Hint = void>
 struct FinalizeData {
-  static inline void Wrapper(napi_env env,
+  static inline void NAPI_CDECL Wrapper(napi_env env,
                              void* data,
                              void* finalizeHint) NAPI_NOEXCEPT {
     WrapVoidCallback([&] {
@@ -209,7 +209,7 @@ template <typename ContextType = void,
           typename Finalizer = std::function<void(Env, void*, ContextType*)>,
           typename FinalizerDataType = void>
 struct ThreadSafeFinalize {
-  static inline void Wrapper(napi_env env,
+  static inline void NAPI_CDECL Wrapper(napi_env env,
                              void* rawFinalizeData,
                              void* /* rawContext */) {
     if (rawFinalizeData == nullptr) return;

--- a/Core/Node-API/Include/Shared/napi/napi.h
+++ b/Core/Node-API/Include/Shared/napi/napi.h
@@ -1861,7 +1861,7 @@ class Error : public ObjectReference
 
  protected:
   /// !cond INTERNAL
-  using create_error_fn = napi_status (*)(napi_env envb,
+  using create_error_fn = napi_status (NAPI_CDECL *) (napi_env envb,
                                           napi_value code,
                                           napi_value msg,
                                           napi_value* result);
@@ -2453,7 +2453,7 @@ class ObjectWrap : public InstanceWrap<T>, public Reference<Object> {
                                                 napi_callback_info info);
   static napi_value StaticSetterCallbackWrapper(napi_env env,
                                                 napi_callback_info info);
-  static void FinalizeCallback(napi_env env, void* data, void* hint);
+  static void NAPI_CDECL FinalizeCallback(napi_env env, void* data, void* hint);
   static Function DefineClass(Napi::Env env,
                               const char* utf8name,
                               const size_t props_count,

--- a/Core/ScriptLoader/CMakeLists.txt
+++ b/Core/ScriptLoader/CMakeLists.txt
@@ -8,6 +8,7 @@ warnings_as_errors(ScriptLoader)
 target_include_directories(ScriptLoader PUBLIC "Include")
 
 target_link_libraries(ScriptLoader
+    PUBLIC Foundation
     PUBLIC napi
     PRIVATE arcana
     PRIVATE UrlLib)

--- a/Core/ScriptLoader/Include/Babylon/ScriptLoader.h
+++ b/Core/ScriptLoader/Include/Babylon/ScriptLoader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 #include <functional>
 #include <memory>
@@ -11,7 +12,7 @@ namespace Babylon
     class ScriptLoader
     {
     public:
-        using DispatchFunctionT = std::function<void(std::function<void(Napi::Env)>)>;
+        using DispatchFunctionT = std::function<void BABYLON_API (std::function<void BABYLON_API (Napi::Env)>)>;
 
         ScriptLoader(DispatchFunctionT dispatchFunction);
 
@@ -29,7 +30,7 @@ namespace Babylon
 
         void LoadScript(std::string url);
         void Eval(std::string source, std::string url);
-        void Dispatch(std::function<void(Napi::Env)> callback);
+        void Dispatch(std::function<void BABYLON_API (Napi::Env)> callback);
 
     private:
         class Impl;

--- a/Core/ScriptLoader/Source/ScriptLoader.cpp
+++ b/Core/ScriptLoader/Source/ScriptLoader.cpp
@@ -82,7 +82,7 @@ namespace Babylon
         m_impl->Eval(std::move(source), std::move(url));
     }
 
-    void ScriptLoader::Dispatch(std::function<void(Napi::Env)> callback)
+    void ScriptLoader::Dispatch(std::function<void BABYLON_API (Napi::Env)> callback)
     {
         m_impl->Dispatch(std::move(callback));
     }

--- a/Polyfills/AbortController/Include/Babylon/Polyfills/AbortController.h
+++ b/Polyfills/AbortController/Include/Babylon/Polyfills/AbortController.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Polyfills::AbortController
 {
-    void Initialize(Napi::Env env);
+    void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Polyfills/AbortController/Source/AbortController.cpp
+++ b/Polyfills/AbortController/Source/AbortController.cpp
@@ -42,7 +42,7 @@ namespace Babylon::Polyfills::Internal
 
 namespace Babylon::Polyfills::AbortController
 {
-    void Initialize(Napi::Env env)
+    void BABYLON_API Initialize(Napi::Env env)
     {
         Internal::AbortController::Initialize(env);
         Internal::AbortSignal::Initialize(env);

--- a/Polyfills/Console/CMakeLists.txt
+++ b/Polyfills/Console/CMakeLists.txt
@@ -7,7 +7,9 @@ warnings_as_errors(Console)
 
 target_include_directories(Console PUBLIC "Include")
 
-target_link_libraries(Console PUBLIC napi)
+target_link_libraries(Console
+    PUBLIC Foundation
+    PUBLIC napi)
 
 set_property(TARGET Console PROPERTY FOLDER Polyfills)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Polyfills/Console/Include/Babylon/Polyfills/Console.h
+++ b/Polyfills/Console/Include/Babylon/Polyfills/Console.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Polyfills::Console
 {
@@ -14,7 +15,7 @@ namespace Babylon::Polyfills::Console
         Error,
     };
 
-    using CallbackT = std::function<void(const char*, LogLevel)>;
+    using CallbackT = std::function<void BABYLON_API (const char*, LogLevel)>;
 
-    void Initialize(Napi::Env env, CallbackT callback);
+    void BABYLON_API Initialize(Napi::Env env, CallbackT callback);
 }

--- a/Polyfills/Console/Source/Console.cpp
+++ b/Polyfills/Console/Source/Console.cpp
@@ -124,7 +124,7 @@ namespace
 
 namespace Babylon::Polyfills::Console
 {
-    void Initialize(Napi::Env env, CallbackT callback)
+    void BABYLON_API Initialize(Napi::Env env, CallbackT callback)
     {
         Napi::HandleScope scope{env};
 

--- a/Polyfills/Scheduling/Include/Babylon/Polyfills/Scheduling.h
+++ b/Polyfills/Scheduling/Include/Babylon/Polyfills/Scheduling.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Polyfills::Scheduling
 {
-    void Initialize(Napi::Env env);
+    void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Polyfills/Scheduling/Source/Scheduling.cpp
+++ b/Polyfills/Scheduling/Source/Scheduling.cpp
@@ -30,7 +30,7 @@ namespace
 
 namespace Babylon::Polyfills::Scheduling
 {
-    void Initialize(Napi::Env env)
+    void BABYLON_API Initialize(Napi::Env env)
     {
         auto global = env.Global();
         if (global.Get(JS_SET_TIMEOUT_NAME).IsUndefined() && global.Get(JS_CLEAR_TIMEOUT_NAME).IsUndefined())

--- a/Polyfills/URL/Include/Babylon/Polyfills/URL.h
+++ b/Polyfills/URL/Include/Babylon/Polyfills/URL.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Polyfills::URL
 {
-    void Initialize(Napi::Env env);
+    void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Polyfills/URL/Source/URL.cpp
+++ b/Polyfills/URL/Source/URL.cpp
@@ -127,7 +127,7 @@ namespace Babylon::Polyfills::Internal
 
 namespace Babylon::Polyfills::URL
 {
-    void Initialize(Napi::Env env)
+    void BABYLON_API Initialize(Napi::Env env)
     {
         Internal::URL::Initialize(env);
         Internal::URLSearchParams::Initialize(env);

--- a/Polyfills/WebSocket/Include/Babylon/Polyfills/WebSocket.h
+++ b/Polyfills/WebSocket/Include/Babylon/Polyfills/WebSocket.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Polyfills::WebSocket
 {
-    void Initialize(Napi::Env env);
+    void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Polyfills/WebSocket/Source/WebSocket.cpp
+++ b/Polyfills/WebSocket/Source/WebSocket.cpp
@@ -280,7 +280,7 @@ namespace Babylon::Polyfills::Internal
 
 namespace Babylon::Polyfills::WebSocket
 {
-    void Initialize(Napi::Env env)
+    void BABYLON_API Initialize(Napi::Env env)
     {
         Internal::WebSocket::Initialize(env);
     }

--- a/Polyfills/XMLHttpRequest/Include/Babylon/Polyfills/XMLHttpRequest.h
+++ b/Polyfills/XMLHttpRequest/Include/Babylon/Polyfills/XMLHttpRequest.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <napi/env.h>
+#include <Babylon/Api.h>
 
 namespace Babylon::Polyfills::XMLHttpRequest
 {
-    void Initialize(Napi::Env env);
+    void BABYLON_API Initialize(Napi::Env env);
 }

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -293,7 +293,7 @@ namespace Babylon::Polyfills::Internal
 
 namespace Babylon::Polyfills::XMLHttpRequest
 {
-    void Initialize(Napi::Env env)
+    void BABYLON_API Initialize(Napi::Env env)
     {
         Internal::XMLHttpRequest::Initialize(env);
     }


### PR DESCRIPTION
Without explicit calling convention modifers, consumers are required to compile with the same calling convention used in the released binaries. If a consumer compiles with the `__stdcall` calling convention, the linker won't resolve the function calls because the released binaries are built with the default `__cdecl` calling convention.

This change fixes the issue using an overridable `BABYLON_API` macro defined as `__cdecl` by default on Windows platforms or defined as empty on non-Windows platforms.