### PR TITLE
Debug traces + CB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # General
 option(JSRUNTIMEHOST_TESTS "Include JsRuntimeHost Tests." ${PROJECT_IS_TOP_LEVEL})
 option(NAPI_BUILD_ABI "Build the ABI layer." ON)
-option(JSRUNTIMEHOST_DEBUG_TRACE "Debug Trace callback."  OFF)
+option(BABYLON_DEBUG_TRACE "Debug Trace callback."  OFF)
 
 # Core
 option(JSRUNTIMEHOST_CORE_APPRUNTIME "Include JsRuntimeHost Core AppRuntime" ON)
@@ -81,8 +81,8 @@ if(JSRUNTIMEHOST_POLYFILL_XMLHTTPREQUEST)
     set_property(TARGET UrlLib PROPERTY FOLDER Dependencies)
 endif()
 
-if(JSRUNTIMEHOST_DEBUG_TRACE)
-    add_definitions(-DJSRUNTIMEHOST_DEBUG_TRACE)
+if(BABYLON_DEBUG_TRACE)
+    add_definitions(-DBABYLON_DEBUG_TRACE)
 endif()
 
 if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # General
 option(JSRUNTIMEHOST_TESTS "Include JsRuntimeHost Tests." ${PROJECT_IS_TOP_LEVEL})
 option(NAPI_BUILD_ABI "Build the ABI layer." ON)
+option(JSRUNTIMEHOST_DEBUG_TRACE "Debug Trace callback."  OFF)
 
 # Core
 option(JSRUNTIMEHOST_CORE_APPRUNTIME "Include JsRuntimeHost Core AppRuntime" ON)
@@ -78,6 +79,10 @@ set_property(TARGET arcana PROPERTY FOLDER Dependencies)
 if(JSRUNTIMEHOST_POLYFILL_XMLHTTPREQUEST)
     FetchContent_MakeAvailable_With_Message(UrlLib)
     set_property(TARGET UrlLib PROPERTY FOLDER Dependencies)
+endif()
+
+if(JSRUNTIMEHOST_DEBUG_TRACE)
+    add_definitions(-DJSRUNTIMEHOST_DEBUG_TRACE)
 endif()
 
 if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR)

--- a/Core/Foundation/CMakeLists.txt
+++ b/Core/Foundation/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(SOURCES
-    "Include/Babylon/Api.h")
+    "Include/Babylon/Api.h"
+    "Include/Babylon/DebugTrace.h"
+    "Source/DebugTrace.cpp")
 
-add_library(Foundation INTERFACE)
+add_library(Foundation ${SOURCES})
 
 target_include_directories(Foundation INTERFACE "Include")
 

--- a/Core/Foundation/Include/Babylon/DebugTrace.h
+++ b/Core/Foundation/Include/Babylon/DebugTrace.h
@@ -1,16 +1,14 @@
 #pragma once
 #include <functional>
 
-#define DEBUG_TRACE_NOOP(...)
-
 #define _STRINGIFY(x) #x
 #define _TOSTRING(x) _STRINGIFY(x)
-#define _DEBUG_TRACE(_format, ...) Babylon::DebugTrace::Trace(__FILE__ "(" _TOSTRING(__LINE__) "): " _format "\n", ##__VA_ARGS__); 
+#define _DEBUG_TRACE(format, ...) Babylon::DebugTrace::Trace(__FILE__ "(" _TOSTRING(__LINE__) "): " format "\n", ##__VA_ARGS__); 
 
 #if JSRUNTIMEHOST_DEBUG_TRACE
 #   define DEBUG_TRACE _DEBUG_TRACE
 #else
-#   define DEBUG_TRACE(...) DEBUG_TRACE_NOOP()
+#   define DEBUG_TRACE(...)
 #endif // JSRUNTIMEHOST_DEBUG_TRACE
 
 namespace Babylon
@@ -18,9 +16,9 @@ namespace Babylon
     namespace DebugTrace
     {
         // off by default.
-        void SetDebugTrace(bool enabled);
+        void EnableDebugTrace(bool enabled);
         // equivalent of a printf that will use TraceOutput function to log. Need DebugTrace to be enabled.
-        void Trace(const char* _format, ...);
+        void Trace(const char* format, ...);
         // set the function used to output.
         void SetTraceOutput(std::function<void(const char* trace)> traceOutputFunction);
     }

--- a/Core/Foundation/Include/Babylon/DebugTrace.h
+++ b/Core/Foundation/Include/Babylon/DebugTrace.h
@@ -1,14 +1,17 @@
 #pragma once
 #include <functional>
 
+#if JSRUNTIMEHOST_DEBUG_TRACE
 #define _STRINGIFY(x) #x
 #define _TOSTRING(x) _STRINGIFY(x)
 #define _DEBUG_TRACE(format, ...) Babylon::DebugTrace::Trace(__FILE__ "(" _TOSTRING(__LINE__) "): " format "\n", ##__VA_ARGS__); 
+#define _DEBUG_RUN(lambda) lambda();
 
-#if JSRUNTIMEHOST_DEBUG_TRACE
-#   define DEBUG_TRACE _DEBUG_TRACE
-#else
-#   define DEBUG_TRACE(...)
+#define DEBUG_TRACE _DEBUG_TRACE
+#define DEBUG_RUN _DEBUG_RUN
+#else // No debugging trace enabled
+#define DEBUG_TRACE(...)
+#define DEBUG_RUN(...)
 #endif // JSRUNTIMEHOST_DEBUG_TRACE
 
 namespace Babylon

--- a/Core/Foundation/Include/Babylon/DebugTrace.h
+++ b/Core/Foundation/Include/Babylon/DebugTrace.h
@@ -1,18 +1,15 @@
 #pragma once
 #include <functional>
 
-#if JSRUNTIMEHOST_DEBUG_TRACE
+#ifdef BABYLON_DEBUG_TRACE
 #define _STRINGIFY(x) #x
 #define _TOSTRING(x) _STRINGIFY(x)
 #define _DEBUG_TRACE(format, ...) Babylon::DebugTrace::Trace(__FILE__ "(" _TOSTRING(__LINE__) "): " format "\n", ##__VA_ARGS__); 
-#define _DEBUG_RUN(lambda) lambda();
 
 #define DEBUG_TRACE _DEBUG_TRACE
-#define DEBUG_RUN _DEBUG_RUN
 #else // No debugging trace enabled
 #define DEBUG_TRACE(...)
-#define DEBUG_RUN(...)
-#endif // JSRUNTIMEHOST_DEBUG_TRACE
+#endif // BABYLON_DEBUG_TRACE
 
 namespace Babylon
 {
@@ -20,7 +17,7 @@ namespace Babylon
     {
         // off by default.
         void EnableDebugTrace(bool enabled);
-        // equivalent of a printf that will use TraceOutput function to log. Need DebugTrace to be enabled.
+        // equivalent of a printf that will use TraceOutput function to log. Need Debug Trace to be enabled.
         void Trace(const char* format, ...);
         // set the function used to output.
         void SetTraceOutput(std::function<void(const char* trace)> traceOutputFunction);

--- a/Core/Foundation/Include/Babylon/DebugTrace.h
+++ b/Core/Foundation/Include/Babylon/DebugTrace.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <functional>
+
+#define DEBUG_TRACE_NOOP(...)
+
+#define _STRINGIFY(x) #x
+#define _TOSTRING(x) _STRINGIFY(x)
+#define _DEBUG_TRACE(_format, ...) Babylon::DebugTrace::Trace(__FILE__ "(" _TOSTRING(__LINE__) "): " _format "\n", ##__VA_ARGS__); 
+
+#if JSRUNTIMEHOST_DEBUG_TRACE
+#   define DEBUG_TRACE _DEBUG_TRACE
+#else
+#   define DEBUG_TRACE(...) DEBUG_TRACE_NOOP()
+#endif // JSRUNTIMEHOST_DEBUG_TRACE
+
+namespace Babylon
+{
+    namespace DebugTrace
+    {
+        // off by default.
+        void SetDebugTrace(bool enabled);
+        // equivalent of a printf that will use TraceOutput function to log. Need DebugTrace to be enabled.
+        void Trace(const char* _format, ...);
+        // set the function used to output.
+        void SetTraceOutput(std::function<void(const char* trace)> traceOutputFunction);
+    }
+}

--- a/Core/Foundation/Source/DebugTrace.cpp
+++ b/Core/Foundation/Source/DebugTrace.cpp
@@ -3,24 +3,24 @@
 #include <stdlib.h>
 #include <functional>
 
+namespace
+{
+    bool s_debugTraceEnabled{};
+    std::function<void(const char* output)> s_traceOutputFunction;
+    void TraceArgs(const char* format, va_list args)
+    {
+        char temp[8192];
+        auto len = vsnprintf(temp, sizeof(temp), format, args);
+        temp[len] = '\0';
+        s_traceOutputFunction(temp);
+    }
+}
+
 namespace Babylon
 {
-    namespace
-    {
-        static bool s_debugTraceEnabled{};
-        static std::function<void(const char* output)> s_traceOutputFunction;
-        static void TraceArgs(const char* format, va_list args)
-        {
-            char temp[8192];
-            auto len = vsnprintf(temp, sizeof(temp), format, args);
-            temp[len] = '\0';
-            s_traceOutputFunction(temp);
-        }
-    }
-
     namespace DebugTrace
     {
-        void SetDebugTrace(bool enabled)
+        void EnableDebugTrace(bool enabled)
         {
             s_debugTraceEnabled = enabled;
         }

--- a/Core/Foundation/Source/DebugTrace.cpp
+++ b/Core/Foundation/Source/DebugTrace.cpp
@@ -6,7 +6,7 @@
 namespace
 {
     bool g_debugTraceEnabled{};
-    std::function<void(const char* output)> s_traceOutputFunction;
+    std::function<void(const char* output)> g_traceOutputFunction;
     void TraceArgs(const char* format, va_list args)
     {
         char temp[8192];
@@ -14,11 +14,11 @@ namespace
         if (len >= 0 && len < sizeof(temp))
         {
             temp[len] = '\0';
-            s_traceOutputFunction(temp);
+            g_traceOutputFunction(temp);
         }
         else
         {
-            s_traceOutputFunction("Error while printing trace string.");
+            g_traceOutputFunction("Error while printing trace string.");
         }
     }
 }
@@ -34,7 +34,7 @@ namespace Babylon
 
         void Trace(const char* format, ...)
         {
-            if (!(g_debugTraceEnabled && s_traceOutputFunction))
+            if (!(g_debugTraceEnabled && g_traceOutputFunction))
             {
                 return;
             }

--- a/Core/Foundation/Source/DebugTrace.cpp
+++ b/Core/Foundation/Source/DebugTrace.cpp
@@ -11,8 +11,15 @@ namespace
     {
         char temp[8192];
         auto len = vsnprintf(temp, sizeof(temp), format, args);
-        temp[len] = '\0';
-        s_traceOutputFunction(temp);
+        if (len >= 0 && len < sizeof(temp))
+        {
+            temp[len] = '\0';
+            s_traceOutputFunction(temp);
+        }
+        else
+        {
+            s_traceOutputFunction("Error while printing trace string.");
+        }
     }
 }
 

--- a/Core/Foundation/Source/DebugTrace.cpp
+++ b/Core/Foundation/Source/DebugTrace.cpp
@@ -5,7 +5,7 @@
 
 namespace
 {
-    bool s_debugTraceEnabled{};
+    bool g_debugTraceEnabled{};
     std::function<void(const char* output)> s_traceOutputFunction;
     void TraceArgs(const char* format, va_list args)
     {
@@ -29,12 +29,12 @@ namespace Babylon
     {
         void EnableDebugTrace(bool enabled)
         {
-            s_debugTraceEnabled = enabled;
+            g_debugTraceEnabled = enabled;
         }
 
         void Trace(const char* format, ...)
         {
-            if (!(s_debugTraceEnabled && s_traceOutputFunction))
+            if (!(g_debugTraceEnabled && s_traceOutputFunction))
             {
                 return;
             }
@@ -46,7 +46,7 @@ namespace Babylon
 
         void SetTraceOutput(std::function<void(const char* trace)> traceOutputFunction)
         {
-            s_traceOutputFunction = std::move(traceOutputFunction);
+            g_traceOutputFunction = std::move(traceOutputFunction);
         }
     }
 }

--- a/Core/Foundation/Source/DebugTrace.cpp
+++ b/Core/Foundation/Source/DebugTrace.cpp
@@ -1,0 +1,45 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <functional>
+
+namespace Babylon
+{
+    namespace
+    {
+        static bool s_debugTraceEnabled{};
+        static std::function<void(const char* output)> s_traceOutputFunction;
+        static void TraceArgs(const char* format, va_list args)
+        {
+            char temp[8192];
+            auto len = vsnprintf(temp, sizeof(temp), format, args);
+            temp[len] = '\0';
+            s_traceOutputFunction(temp);
+        }
+    }
+
+    namespace DebugTrace
+    {
+        void SetDebugTrace(bool enabled)
+        {
+            s_debugTraceEnabled = enabled;
+        }
+
+        void Trace(const char* format, ...)
+        {
+            if (!(s_debugTraceEnabled && s_traceOutputFunction))
+            {
+                return;
+            }
+            va_list args;
+            va_start(args, format);
+            TraceArgs(format, args);
+            va_end(args);
+        }
+
+        void SetTraceOutput(std::function<void(const char* trace)> traceOutputFunction)
+        {
+            s_traceOutputFunction = std::move(traceOutputFunction);
+        }
+    }
+}

--- a/Core/JsRuntime/Source/JsRuntime.cpp
+++ b/Core/JsRuntime/Source/JsRuntime.cpp
@@ -1,4 +1,5 @@
 #include "JsRuntime.h"
+#include "Babylon/DebugTrace.h"
 
 namespace Babylon
 {
@@ -23,6 +24,8 @@ namespace Babylon
 
         Napi::Value jsRuntime = Napi::External<JsRuntime>::New(env, this, [](Napi::Env, JsRuntime* runtime) { delete runtime; });
         jsNative.Set(JS_RUNTIME_NAME, jsRuntime);
+
+        DEBUG_TRACE("JsRuntime created");
     }
 
     JsRuntime& BABYLON_API JsRuntime::CreateForJavaScript(Napi::Env env, DispatchFunctionT dispatchFunction)

--- a/Core/ScriptLoader/Source/ScriptLoader.cpp
+++ b/Core/ScriptLoader/Source/ScriptLoader.cpp
@@ -23,6 +23,7 @@ namespace Babylon
             m_task = arcana::when_all(m_task, request.SendAsync()).then(arcana::inline_scheduler, arcana::cancellation::none(), [dispatchFunction = m_dispatchFunction, request = std::move(request), url = std::move(url)](auto) mutable {
                 arcana::task_completion_source<void, std::exception_ptr> taskCompletionSource{};
                 dispatchFunction([taskCompletionSource, request = std::move(request), url = std::move(url)](Napi::Env env) mutable {
+                    DEBUG_TRACE("Evaluating script at url %s", url.c_str());
                     Napi::Eval(env, request.ResponseString().data(), url.data());
                     taskCompletionSource.complete();
                 });
@@ -36,7 +37,6 @@ namespace Babylon
                 [dispatchFunction = m_dispatchFunction, source = std::move(source), url = std::move(url)](auto) mutable {
                     arcana::task_completion_source<void, std::exception_ptr> taskCompletionSource{};
                     dispatchFunction([taskCompletionSource, source = std::move(source), url = std::move(url)](Napi::Env env) mutable {
-                        DEBUG_TRACE("Evaluating script at url %s", url.c_str());
                         Napi::Eval(env, source.data(), url.data());
                         taskCompletionSource.complete();
                     });

--- a/Core/ScriptLoader/Source/ScriptLoader.cpp
+++ b/Core/ScriptLoader/Source/ScriptLoader.cpp
@@ -1,6 +1,7 @@
 #include <Babylon/ScriptLoader.h>
 #include <UrlLib/UrlLib.h>
 #include <arcana/threading/task.h>
+#include "Babylon/DebugTrace.h"
 
 namespace Babylon
 {
@@ -16,6 +17,7 @@ namespace Babylon
         void LoadScript(std::string url)
         {
             UrlLib::UrlRequest request;
+            DEBUG_TRACE("Loading script at url %s", url.c_str());
             request.Open(UrlLib::UrlMethod::Get, url);
             request.ResponseType(UrlLib::UrlResponseType::String);
             m_task = arcana::when_all(m_task, request.SendAsync()).then(arcana::inline_scheduler, arcana::cancellation::none(), [dispatchFunction = m_dispatchFunction, request = std::move(request), url = std::move(url)](auto) mutable {
@@ -34,6 +36,7 @@ namespace Babylon
                 [dispatchFunction = m_dispatchFunction, source = std::move(source), url = std::move(url)](auto) mutable {
                     arcana::task_completion_source<void, std::exception_ptr> taskCompletionSource{};
                     dispatchFunction([taskCompletionSource, source = std::move(source), url = std::move(url)](Napi::Env env) mutable {
+                        DEBUG_TRACE("Evaluating script at url %s", url.c_str());
                         Napi::Eval(env, source.data(), url.data());
                         taskCompletionSource.complete();
                     });

--- a/Tests/UnitTests/Android/app/src/main/cpp/JNI.cpp
+++ b/Tests/UnitTests/Android/app/src/main/cpp/JNI.cpp
@@ -3,7 +3,7 @@
 #include <AndroidExtensions/Globals.h>
 #include <AndroidExtensions/JavaWrappers.h>
 #include <AndroidExtensions/StdoutLogger.h>
-
+#include "Babylon/DebugTrace.h"
 #include <Shared/Shared.h>
 
 extern "C" JNIEXPORT jint JNICALL
@@ -20,6 +20,9 @@ Java_com_jsruntimehost_unittests_Native_javaScriptTests(JNIEnv* env, jclass claz
     android::StdoutLogger::Start();
 
     android::global::Initialize(javaVM, context);
+
+    Babylon::DebugTrace::EnableDebugTrace(true);
+    Babylon::DebugTrace::SetTraceOutput([](const char* trace) { printf("%s\n", trace); });
 
     auto testResult = RunTests();
 

--- a/Tests/UnitTests/Android/app/src/main/cpp/JNI.cpp
+++ b/Tests/UnitTests/Android/app/src/main/cpp/JNI.cpp
@@ -22,7 +22,7 @@ Java_com_jsruntimehost_unittests_Native_javaScriptTests(JNIEnv* env, jclass claz
     android::global::Initialize(javaVM, context);
 
     Babylon::DebugTrace::EnableDebugTrace(true);
-    Babylon::DebugTrace::SetTraceOutput([](const char* trace) { printf("%s\n", trace); });
+    Babylon::DebugTrace::SetTraceOutput([](const char* trace) { printf("%s\n", trace); fflush(stdout); });
 
     auto testResult = RunTests();
 

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(UnitTests
     PRIVATE XMLHttpRequest
     PRIVATE WebSocket
     PRIVATE gtest_main
+    PRIVATE Foundation
     ${ADDITIONAL_LIBRARIES})
 
 # See https://gitlab.kitware.com/cmake/cmake/-/issues/23543

--- a/Tests/UnitTests/Linux/App.cpp
+++ b/Tests/UnitTests/Linux/App.cpp
@@ -5,7 +5,7 @@
 int main()
 {
     Babylon::DebugTrace::EnableDebugTrace(true);
-    Babylon::DebugTrace::SetTraceOutput([](const char* trace) { printf("%s\n", trace); });
+    Babylon::DebugTrace::SetTraceOutput([](const char* trace) { printf("%s\n", trace); fflush(stdout); });
 
     return RunTests();
 }

--- a/Tests/UnitTests/Linux/App.cpp
+++ b/Tests/UnitTests/Linux/App.cpp
@@ -1,5 +1,6 @@
 #include "../Shared/Shared.h"
 #include "Babylon/DebugTrace.h"
+#include <cstdio>
 
 int main()
 {

--- a/Tests/UnitTests/Linux/App.cpp
+++ b/Tests/UnitTests/Linux/App.cpp
@@ -1,6 +1,10 @@
 #include "../Shared/Shared.h"
+#include "Babylon/DebugTrace.h"
 
 int main()
 {
+    Babylon::DebugTrace::EnableDebugTrace(true);
+    Babylon::DebugTrace::SetTraceOutput([](const char* trace) { printf("%s\n", trace); });
+
     return RunTests();
 }

--- a/Tests/UnitTests/Win32/App.cpp
+++ b/Tests/UnitTests/Win32/App.cpp
@@ -6,7 +6,7 @@ int main()
 {
     SetConsoleOutputCP(CP_UTF8);
 
-    Babylon::DebugTrace::SetDebugTrace(true);
+    Babylon::DebugTrace::EnableDebugTrace(true);
     Babylon::DebugTrace::SetTraceOutput([](const char* trace) { OutputDebugStringA(trace); });
 
     return RunTests();

--- a/Tests/UnitTests/Win32/App.cpp
+++ b/Tests/UnitTests/Win32/App.cpp
@@ -9,9 +9,5 @@ int main()
     Babylon::DebugTrace::EnableDebugTrace(true);
     Babylon::DebugTrace::SetTraceOutput([](const char* trace) { OutputDebugStringA(trace); });
 
-    DEBUG_RUN([]() {
-        DEBUG_TRACE("This will stop the debugger");
-        DebugBreak();
-        });
     return RunTests();
 }

--- a/Tests/UnitTests/Win32/App.cpp
+++ b/Tests/UnitTests/Win32/App.cpp
@@ -9,5 +9,9 @@ int main()
     Babylon::DebugTrace::EnableDebugTrace(true);
     Babylon::DebugTrace::SetTraceOutput([](const char* trace) { OutputDebugStringA(trace); });
 
+    DEBUG_RUN([]() {
+        DEBUG_TRACE("This will stop the debugger");
+        DebugBreak();
+        });
     return RunTests();
 }

--- a/Tests/UnitTests/Win32/App.cpp
+++ b/Tests/UnitTests/Win32/App.cpp
@@ -1,9 +1,13 @@
 #include "../Shared/Shared.h"
 #include <Windows.h>
+#include "Babylon/DebugTrace.h"
 
 int main()
 {
     SetConsoleOutputCP(CP_UTF8);
+
+    Babylon::DebugTrace::SetDebugTrace(true);
+    Babylon::DebugTrace::SetTraceOutput([](const char* trace) { OutputDebugStringA(trace); });
 
     return RunTests();
 }

--- a/Tests/UnitTests/iOS/App.mm
+++ b/Tests/UnitTests/iOS/App.mm
@@ -1,8 +1,12 @@
 #include "../Shared/Shared.h"
+#include "Babylon/DebugTrace.h"
 #include <iostream>
 
 int main()
 {
+    Babylon::DebugTrace::EnableDebugTrace(true);
+    Babylon::DebugTrace::SetTraceOutput([](const char* trace) { NSLog(@"%@", trace); });
+
     int exitCode = RunTests();
 
     // CI will pick up the exit code from stderr when running in the iOS Simulator.

--- a/Tests/UnitTests/iOS/App.mm
+++ b/Tests/UnitTests/iOS/App.mm
@@ -1,6 +1,7 @@
 #include "../Shared/Shared.h"
 #include "Babylon/DebugTrace.h"
 #include <iostream>
+#import <Foundation/Foundation.h>
 
 int main()
 {

--- a/Tests/UnitTests/macOS/App.mm
+++ b/Tests/UnitTests/macOS/App.mm
@@ -1,6 +1,10 @@
 #include "../Shared/Shared.h"
+#include "Babylon/DebugTrace.h"
 
 int main()
 {
+    Babylon::DebugTrace::EnableDebugTrace(true);
+    Babylon::DebugTrace::SetTraceOutput([](const char* trace) { NSLog(@"%@", trace); });
+
     return RunTests();
 }

--- a/Tests/UnitTests/macOS/App.mm
+++ b/Tests/UnitTests/macOS/App.mm
@@ -1,5 +1,6 @@
 #include "../Shared/Shared.h"
 #include "Babylon/DebugTrace.h"
+#import <Foundation/Foundation.h>
 
 int main()
 {


### PR DESCRIPTION
Documentation will be part of BabylonNative.

2 levels of logging
# Code logging
Works are a console log. Enable Debug Trace (off by default) and set an outputter(none set by default) then call Trace.
```
SetTraceOutput([](const char *trace){
printf("%s\n", trace);
});
SetDebugTrace(true);
...
Trace("Error detected.");
```

# Babylon code instrumentation
Babylon code is instrumented and will use Trace function described earlier IF `JSRUNTIMEHOST_DEBUG_TRACE` preprocessor is defined. If it's not (default), no log will happen and no performance impact.

To summarize, user can log in his own code with Babylon logging API. Babylon Native and JSRuntimeHost code is instrumented but will only log if  `JSRUNTIMEHOST_DEBUG_TRACE` preprocessor is defined and logging is enabled and an outputer function is set.

Thread safety in the logging output is responsability of the user.