### PR TITLE
V8 build fixes for x86

### DIFF
--- a/Core/AppRuntime/V8Inspector/CMakeLists.txt
+++ b/Core/AppRuntime/V8Inspector/CMakeLists.txt
@@ -19,7 +19,8 @@ target_include_directories(v8inspector
     PRIVATE "${llhttp_SOURCE_DIR}/include")
 
 target_compile_definitions(v8inspector
-    PRIVATE ASIO_STANDALONE)
+    PRIVATE ASIO_STANDALONE
+    PRIVATE NOMINMAX)
 
 target_link_libraries(v8inspector
     PRIVATE asio

--- a/Core/AppRuntime/V8Inspector/Include/V8Inc.h
+++ b/Core/AppRuntime/V8Inspector/Include/V8Inc.h
@@ -1,16 +1,17 @@
 #pragma once
 
-// Enable V8 Pointer Compression
-// https://v8.dev/blog/pointer-compression
-// https://stackoverflow.com/q/62921373
+#include <stdint.h>
+
+#if INTPTR_MAX == INT64_MAX
 #ifndef V8_COMPRESS_POINTERS
 #define V8_COMPRESS_POINTERS 1
 #endif
-
-// Enable V8 Sandbox
-// https://v8.dev/blog/sandbox
+#ifndef V8_31BIT_SMIS_ON_64BIT_ARCH
+#define V8_31BIT_SMIS_ON_64BIT_ARCH 1
+#endif
 #ifndef V8_ENABLE_SANDBOX
 #define V8_ENABLE_SANDBOX 1
+#endif
 #endif
 
 #ifdef _MSC_VER

--- a/Core/Node-API/Include/Engine/V8/napi/env.h
+++ b/Core/Node-API/Include/Engine/V8/napi/env.h
@@ -2,17 +2,18 @@
 
 #include <napi/napi.h>
 
-// Enable V8 Pointer Compression
-// https://v8.dev/blog/pointer-compression
-// https://stackoverflow.com/q/62921373
+#include <stdint.h>
+
+#if INTPTR_MAX == INT64_MAX
 #ifndef V8_COMPRESS_POINTERS
 #define V8_COMPRESS_POINTERS 1
 #endif
-
-// Enable V8 Sandbox
-// https://v8.dev/blog/sandbox
+#ifndef V8_31BIT_SMIS_ON_64BIT_ARCH
+#define V8_31BIT_SMIS_ON_64BIT_ARCH 1
+#endif
 #ifndef V8_ENABLE_SANDBOX
 #define V8_ENABLE_SANDBOX 1
+#endif
 #endif
 
 #ifdef __clang__

--- a/Core/Node-API/Source/js_native_api_v8_internals.h
+++ b/Core/Node-API/Source/js_native_api_v8_internals.h
@@ -13,17 +13,20 @@
 // are bridged to remove references to the `node` namespace. `node_version.h`,
 // included below, defines `NAPI_VERSION`.
 
-// [BABYLON-NATIVE-ADDITION]: Enable V8 Pointer Compression
-// https://v8.dev/blog/pointer-compression
-// https://stackoverflow.com/q/62921373
+// [BABYLON-NATIVE-ADDITION]: For INTPTR_MAX and INT64_MAX
+#include <stdint.h>
+
+// [BABYLON-NATIVE-ADDITION]: Enable V8 Pointer Compression and Sandbox for 64-bit architecture
+#if INTPTR_MAX == INT64_MAX
 #ifndef V8_COMPRESS_POINTERS
 #define V8_COMPRESS_POINTERS 1
 #endif
-
-// [BABYLON-NATIVE-ADDITION]: Enable V8 Sandbox
-// https://v8.dev/blog/sandbox
+#ifndef V8_31BIT_SMIS_ON_64BIT_ARCH
+#define V8_31BIT_SMIS_ON_64BIT_ARCH 1
+#endif
 #ifndef V8_ENABLE_SANDBOX
 #define V8_ENABLE_SANDBOX 1
+#endif
 #endif
 
 #include <v8.h>

--- a/Tests/UnitTests/Android/gradle.properties
+++ b/Tests/UnitTests/Android/gradle.properties
@@ -19,3 +19,5 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Select the JavaScript engine to use
+#jsEngine=JavaScriptCore


### PR DESCRIPTION
Pointer compression, etc. cannot be on for x86 builds when targeting V8.

V8 compile will currently fail if pointer compression is turned on:
> Pointer compression can be enabled only for 64-bit architectures

See https://github.com/v8/v8/blob/main/include/v8-internal.h#L165-L167

This change just makes it such that the macros are defined only for x64.