### PR TITLE
switch ArrayBuffer constructor

### DIFF
--- a/Core/Node-API-Extensions/include/napi/pointer.h
+++ b/Core/Node-API-Extensions/include/napi/pointer.h
@@ -32,8 +32,7 @@ namespace Napi
         static Napi::Value Create(Napi::Env env, ReturnT (ClassT::*functionPtr)(ArgsT...))
         {
             using PointerT = decltype(functionPtr);
-            auto arrayBuffer = Napi::ArrayBuffer::New(env, PointerTraits<PointerT>::ByteSize);
-            std::memcpy(arrayBuffer.Data(), &functionPtr, sizeof(PointerT));
+            auto arrayBuffer = Napi::ArrayBuffer::New(env, &functionPtr, PointerTraits<PointerT>::ByteSize);
             return Napi::Uint32Array::New(env, PointerTraits<PointerT>::ArraySize, arrayBuffer, 0).template As<Napi::Value>();
         }
     };
@@ -45,8 +44,7 @@ namespace Napi
         static Napi::Value Create(Napi::Env env, const T* pointer)
         {
             using PointerT = T*;
-            auto arrayBuffer = Napi::ArrayBuffer::New(env, PointerTraits<PointerT>::ByteSize);
-            std::memcpy(arrayBuffer.Data(), &pointer, sizeof(PointerT));
+            auto arrayBuffer = Napi::ArrayBuffer::New(env, &pointer, PointerTraits<PointerT>::ByteSize);
             return Napi::Uint32Array::New(env, PointerTraits<PointerT>::ArraySize, arrayBuffer, 0);
         }
 
@@ -60,8 +58,9 @@ namespace Napi
                 callback();
                 delete reinterpret_cast<DataT*>(ptr);
             };
-            auto arrayBuffer = Napi::ArrayBuffer::New(env, new DataT, PointerTraits<PointerT>::ByteSize, std::move(finalizer));
-            std::memcpy(arrayBuffer.Data(), &pointer, sizeof(PointerT));
+            DataT* data = new DataT;
+            std::memcpy(data, &pointer, sizeof(PointerT));
+            auto arrayBuffer = Napi::ArrayBuffer::New(env, data, PointerTraits<PointerT>::ByteSize, std::move(finalizer));
             return Napi::Uint32Array::New(env, PointerTraits<PointerT>::ArraySize, arrayBuffer, 0);
         }
 


### PR DESCRIPTION
I'd like to be able to incorporate [emnapi](https://emnapi-docs.vercel.app/) as an emscripten-based backend for JsRuntimeHost, but it has a limitation in that it can't properly expose the backing memory of an allocated ArrayBuffer as writable without an extra memory synchronization call after it has been constructed [[issue]](https://github.com/toyobayashi/emnapi/issues/128).  This doesn't seem to be an issue if the memory given to the ArrayBuffer constructor is fully initialized.  Would you mind if this were switched to pass the initialized memory as input rather than attempt to modify the backing buffer after construction?  Existing tests pass and BabylonNative on emscripten runs correctly.