### PR TITLE
AppRuntime iOS EnableDebugger

### DIFF
--- a/Core/AppRuntime/Source/AppRuntime_iOS.mm
+++ b/Core/AppRuntime/Source/AppRuntime_iOS.mm
@@ -13,6 +13,24 @@ namespace Babylon
         RunEnvironmentTier();
     }
 
+    void AppRuntime::RunEnvironmentTier(const char*)
+    {
+        auto globalContext = JSGlobalContextCreateInGroup(nullptr, nullptr);
+
+        if (@available(iOS 16.4, *)) {
+            JSGlobalContextSetInspectable(globalContext, m_options.EnableDebugger);
+        }
+
+        Napi::Env env = Napi::Attach(globalContext);
+
+        Run(env);
+
+        JSGlobalContextRelease(globalContext);
+
+        // Detach must come after JSGlobalContextRelease since it triggers finalizers which require env.
+        Napi::Detach(env);
+    }
+
     void AppRuntime::Execute(Dispatchable<void()> callback)
     {
         @autoreleasepool


### PR DESCRIPTION
hi, in order to run `JSGlobalContextSetInspectable` there needs to be check around it for iOS 16.4
````
        if (@available(iOS 16.4, *)) {
            JSGlobalContextSetInspectable(globalContext, m_options.EnableDebugger);
        }
````

i noticed that `AppRuntime_iOS.mm` was calling `RunEnvironmentTier` in `AppRuntime_JavaScriptCore.cpp`
however because its inside a cpp file, @available syntax was not allowed.

ive duplicated the `RunEnvironmentTier` function and moved it to `AppRuntime_iOS.mm` where @available check can run.