### PR TITLE
Fixing various issues with build pipeline

### DIFF
--- a/.github/azure-pipelines.yml
+++ b/.github/azure-pipelines.yml
@@ -76,16 +76,16 @@ jobs:
   # iOS
   - template: jobs/ios.yml
     parameters:
-      name: 'iOS_Xcode142'
+      name: 'iOS_Xcode162'
       vmImage: 'macOS-latest'
-      xCodeVersion: 14.2
-      simulator: 'iPhone 11'
+      xCodeVersion: 16.2
+      simulator: 'iPhone 16'
 
   - template: jobs/ios.yml
     parameters:
-      name: 'iOS_Xcode150'
+      name: 'iOS_Xcode152'
       vmImage: 'macOS-13'
-      xCodeVersion: 15.0
+      xCodeVersion: 15.2
       simulator: 'iPhone 14'
 
   # Linux

--- a/.github/jobs/android.yml
+++ b/.github/jobs/android.yml
@@ -9,11 +9,12 @@ jobs:
   timeoutInMinutes: 30
 
   pool:
-    vmImage: macos-latest
+    vmImage: macos-13
 
   steps:
   - script: |
       echo Install Android image
+      export JAVA_HOME=$JAVA_HOME_8_X64
       echo 'y' | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-27;default;x86_64'
       echo 'y' | $ANDROID_HOME/tools/bin/sdkmanager --licenses
       echo Create AVD
@@ -22,7 +23,7 @@ jobs:
 
   - script: |
       echo Start emulator
-      nohup $ANDROID_HOME/emulator/emulator -avd Pixel_API_27 -gpu host -no-window 2>&1 &
+      nohup $ANDROID_HOME/emulator/emulator -avd Pixel_API_27 -gpu host -no-window -no-audio -no-boot-anim 2>&1 &
       echo Wait for emulator
       $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do echo '.'; sleep 1; done'
       $ANDROID_HOME/platform-tools/adb devices

--- a/.github/jobs/android.yml
+++ b/.github/jobs/android.yml
@@ -39,9 +39,10 @@ jobs:
     displayName: 'Run Connected Android Test'
 
   - script: |
-      export results=$(find ./app/build/outputs/androidTest-results -name "*.txt")
-      echo cat "$results"
-      cat "$results"
+      find ./app/build/outputs/androidTest-results -name "*.txt" -print0 | while IFS= read -r -d '' file; do
+        echo "cat \"$file\""
+        cat "$file"
+      done
     workingDirectory: 'Tests/UnitTests/Android'
     condition: succeededOrFailed()
     displayName: 'Dump logcat from Test Results'

--- a/.github/jobs/android.yml
+++ b/.github/jobs/android.yml
@@ -35,7 +35,7 @@ jobs:
       workingDirectory: 'Tests/UnitTests/Android'
       options: '-PabiFilters=x86_64 -PjsEngine=${{parameters.jsEngine}} -PndkVersion=$(ndkVersion)'
       tasks: 'connectedAndroidTest'
-      jdkVersionOption: 1.11
+      jdkVersionOption: 1.17
     displayName: 'Run Connected Android Test'
 
   - script: |

--- a/.github/jobs/ios.yml
+++ b/.github/jobs/ios.yml
@@ -20,6 +20,11 @@ jobs:
       cmake -B Build/iOS -G Xcode -D IOS=ON
     displayName: 'Configure CMake'
 
+  - script: |
+      echo Boot "${{parameters.simulator}}"
+      xcrun simctl boot "${{parameters.simulator}}"
+    displayName: 'Boot Simulator'
+
   - task: Xcode@5
     inputs:
       xcWorkspacePath: 'Build/iOS/JsRuntimeHost.xcodeproj'
@@ -30,8 +35,6 @@ jobs:
     displayName: 'Build Xcode Project'
 
   - script: |
-      echo Boot "${{parameters.simulator}}"
-      xcrun simctl boot "${{parameters.simulator}}"
       echo Install UnitTests app
       xcrun simctl install booted "Build/iOS/Tests/UnitTests/RelWithDebInfo-iphonesimulator/UnitTests.app"
       echo Launch UnitTests app

--- a/.github/jobs/macos.yml
+++ b/.github/jobs/macos.yml
@@ -7,8 +7,8 @@ jobs:
 
   steps:
   - script: |
-      sudo xcode-select --switch /Applications/Xcode_14.0.app/Contents/Developer
-    displayName: 'Select Xcode 14.0'
+      sudo xcode-select --switch /Applications/Xcode_15.1.app/Contents/Developer
+    displayName: 'Select Xcode 15.1'
 
   - script: |
       cmake -B Build/macOS -GXcode

--- a/Tests/UnitTests/Android/app/build.gradle
+++ b/Tests/UnitTests/Android/app/build.gradle
@@ -10,7 +10,7 @@ if (project.hasProperty("jsEngine")) {
 android {
     namespace 'com.jsruntimehost.unittests'
     compileSdk 33
-    ndkVersion = "21.4.7075529"
+    ndkVersion = "23.1.7779620"
     if (project.hasProperty("ndkVersion")) {
         ndkVersion = project.property("ndkVersion")
     }

--- a/Tests/UnitTests/Android/build.gradle
+++ b/Tests/UnitTests/Android/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
+    id 'com.android.application' version '8.8.0' apply false
+    id 'com.android.library' version '8.8.0' apply false
 }

--- a/Tests/UnitTests/Android/gradle.properties
+++ b/Tests/UnitTests/Android/gradle.properties
@@ -19,5 +19,7 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false
 # Select the JavaScript engine to use
 #jsEngine=JavaScriptCore

--- a/Tests/UnitTests/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Tests/UnitTests/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jan 20 12:19:56 PST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Fixing a bunch of things that have broken in the build pipeline with build agent updates over the last few months:
- MacOS & iOS: Use newer versions of Xcode (14 is no longer available)
- iOS: On either newer MacOS versions or Xcode versions, the emulator has to be booted before the build, otherwise the build thinks there is no available "destination" for the build.
- Android: SDKManager requires Java 8, which is no longer the default, so it needs to be set explicitly before running SDKManager.
- Android: The emulator boot has errors if audio isn't disabled, so disabling audio (and splash screen to make it faster).
- Android: The pipeline is setup to use an x86/x64 emulator, but the newer MacOS build agent images are arm64. For now I just switched these pipelines back to macos-13. Separately we can probably update the pipeline to use arm64 emulator images.
- Android: The build would not deploy on the device. I tried locally and got the same behavior. The only way I could get it to work was to upgrade gradle. I did this with the upgrade assistant in Android Studio.
- Android: With the newer version of gradle, I also had to update to Java 17 when running the gradle command.
- Android: Once the build was deploying, I was getting a runtime error that seemed to be related to how the app interfaces with the emulator. After some research, I found that I needed to upgrade the NDK to 23. I assume this is because we are using a newer version of the emulator itself (not the device image or API level).
- Android: With the gradle update, the gradle version is now in the test result file names, but with spaces (e.g. `Pixel_API_27(AVD) - 8.1.0/aapt.1.ok.txt`), so I had to update the script that dumps the contents of these files to the console.