### PR TITLE
Nightly build

### DIFF
--- a/.github/azure-pipelines.yml
+++ b/.github/azure-pipelines.yml
@@ -4,6 +4,14 @@ trigger:
 pr:
 - main
 
+schedules:
+- cron: "0 0 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+    - main
+  always: true
+
 variables:
 - name: ndkVersion
   value: 25.2.9519653

--- a/.github/azure-pipelines.yml
+++ b/.github/azure-pipelines.yml
@@ -9,8 +9,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-    - nightly-build
-    # - main
+    - main
   always: true
 
 variables:

--- a/.github/azure-pipelines.yml
+++ b/.github/azure-pipelines.yml
@@ -9,7 +9,8 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-    - main
+    - nightly-build
+    # - main
   always: true
 
 variables:


### PR DESCRIPTION
Setup a schedule for a nightly build. Tested it on a side branch and it triggered the build: https://dev.azure.com/babylonjs/ContinousIntegration/_build/results?buildId=36833&view=results
(Build failed, but that's a different issue...)