### PR TITLE
Add additional constructor callback check for nullptr

### DIFF
--- a/Core/Node-API/Source/js_native_api_javascriptcore.cc
+++ b/Core/Node-API/Source/js_native_api_javascriptcore.cc
@@ -337,7 +337,7 @@ namespace {
         return nullptr;
       }
 
-      return ToJSObject(env, result);
+      return result != nullptr ? ToJSObject(env, result) : instance;
     }
 
     // JSObjectFinalizeCallback


### PR DESCRIPTION
If a JS object constructor is defined natively, and the native callback returns nullptr, we should return the JS object instance instead of nullptr. This behavior should match what happens with other JS engines by default.