### PR TITLE
Add Blob polyfill

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ option(JSRUNTIMEHOST_POLYFILL_XMLHTTPREQUEST "Include JsRuntimeHost Polyfill XML
 option(JSRUNTIMEHOST_POLYFILL_URL "Include JsRuntimeHost Polyfill URL and URLSearchParams." ON)
 option(JSRUNTIMEHOST_POLYFILL_ABORT_CONTROLLER "Include JsRuntimeHost Polyfills AbortController and AbortSignal." ON)
 option(JSRUNTIMEHOST_POLYFILL_WEBSOCKET "Include JsRuntimeHost Polyfill WebSocket." ON)
+option(JSRUNTIMEHOST_POLYFILL_BLOB "Include JsRuntimeHost Polyfill Blob." ON)
 
 # --------------------------------------------------
 

--- a/Core/Node-API-JSI/Include/napi/napi-inl.h
+++ b/Core/Node-API-JSI/Include/napi/napi-inl.h
@@ -241,7 +241,25 @@ inline bool Value::IsArrayBuffer() const {
 }
 
 inline bool Value::IsTypedArray() const {
-  throw std::runtime_error{"TODO"};
+    if (!_value.isObject()) {
+        return false;
+    }
+
+    auto object{_value.getObject(_env->rt)};
+    try {
+        const auto name{object.getPropertyAsObject(_env->rt, "constructor").getProperty(_env->rt, "name").getString(_env->rt).utf8(_env->rt)};
+        return name == "Int8Array" ||
+               name == "Uint8Array" ||
+               name == "Uint8ClampedArray" ||
+               name == "Int16Array" ||
+               name == "Uint16Array" ||
+               name == "Int32Array" ||
+               name == "Uint32Array" ||
+               name == "Float32Array" ||
+               name == "Float64Array";
+    } catch (const jsi::JSIException&) {
+        return false;
+    }
 }
 
 inline bool Value::IsObject() const {
@@ -257,7 +275,17 @@ inline bool Value::IsPromise() const {
 }
 
 inline bool Value::IsDataView() const {
-  throw std::runtime_error{"TODO"};
+    if (!_value.isObject()) {
+        return false;
+    }
+
+    auto object{_value.getObject(_env->rt)};
+    try {
+        const auto name{object.getPropertyAsObject(_env->rt, "constructor").getProperty(_env->rt, "name").getString(_env->rt).utf8(_env->rt)};
+        return name == "DataView";
+    } catch (const jsi::JSIException&) {
+        return false;
+    }
 }
 
 inline bool Value::IsExternal() const {

--- a/Polyfills/Blob/CMakeLists.txt
+++ b/Polyfills/Blob/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(SOURCES 
+    "Include/Babylon/Polyfills/Blob.h"
+    "Source/Blob.cpp"
+    "Source/Blob.h")
+
+add_library(Blob ${SOURCES})
+warnings_as_errors(Blob)
+
+target_include_directories(Blob PUBLIC "Include")
+
+target_link_libraries(Blob
+    PUBLIC JsRuntime)
+
+set_property(TARGET Blob PROPERTY FOLDER Polyfills)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Polyfills/Blob/Include/Babylon/Polyfills/Blob.h
+++ b/Polyfills/Blob/Include/Babylon/Polyfills/Blob.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <napi/env.h>
+#include <Babylon/Api.h>
+
+namespace Babylon::Polyfills::Blob
+{
+    void BABYLON_API Initialize(Napi::Env env);
+}

--- a/Polyfills/Blob/Source/Blob.cpp
+++ b/Polyfills/Blob/Source/Blob.cpp
@@ -7,24 +7,21 @@ namespace Babylon::Polyfills::Internal
     void Blob::Initialize(Napi::Env env)
     {
         static constexpr auto JS_BLOB_CONSTRUCTOR_NAME = "Blob";
-
-        Napi::Function func = DefineClass(
-            env,
-            JS_BLOB_CONSTRUCTOR_NAME,
-            {
-                InstanceAccessor("size", &Blob::GetSize, nullptr),
-                InstanceAccessor("type", &Blob::GetType, nullptr),
-                InstanceMethod("text", &Blob::Text),
-                InstanceMethod("arrayBuffer", &Blob::ArrayBuffer),
-                InstanceMethod("bytes", &Blob::Bytes)
-            });
-
         if (env.Global().Get(JS_BLOB_CONSTRUCTOR_NAME).IsUndefined())
         {
+            Napi::Function func = DefineClass(
+                env,
+                JS_BLOB_CONSTRUCTOR_NAME,
+                {
+                    InstanceAccessor("size", &Blob::GetSize, nullptr),
+                    InstanceAccessor("type", &Blob::GetType, nullptr),
+                    InstanceMethod("text", &Blob::Text),
+                    InstanceMethod("arrayBuffer", &Blob::ArrayBuffer),
+                    InstanceMethod("bytes", &Blob::Bytes)
+                });
+
             env.Global().Set(JS_BLOB_CONSTRUCTOR_NAME, func);
         }
-
-        JsRuntime::NativeObject::GetFromJavaScript(env).Set(JS_BLOB_CONSTRUCTOR_NAME, func);
     }
 
     Blob::Blob(const Napi::CallbackInfo& info)

--- a/Polyfills/Blob/Source/Blob.cpp
+++ b/Polyfills/Blob/Source/Blob.cpp
@@ -38,7 +38,7 @@ namespace Babylon::Polyfills::Internal
 
                 if (blobParts.Length() > 1)
                 {
-                    throw Napi::Error::New(Env(), "Blob constructor only supports a single BlobPart in the BlobParts array.");
+                    throw Napi::Error::New(Env(), "Using multiple BlobParts in Blob constructor is not implemented.");
                 }
             }
         }

--- a/Polyfills/Blob/Source/Blob.h
+++ b/Polyfills/Blob/Source/Blob.h
@@ -23,7 +23,7 @@ namespace Babylon::Polyfills::Internal
 
         void ProcessBlobPart(const Napi::Value& blobPart);
 
-        std::vector<uint8_t> m_data;
+        std::vector<std::byte> m_data;
         std::string m_type;
     };
 }

--- a/Polyfills/Blob/Source/Blob.h
+++ b/Polyfills/Blob/Source/Blob.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <napi/napi.h>
+
+#include <vector>
+#include <string>
+
+namespace Babylon::Polyfills::Internal
+{
+    class Blob : public Napi::ObjectWrap<Blob>
+    {
+    public:
+        static void Initialize(Napi::Env env);
+
+        explicit Blob(const Napi::CallbackInfo& info);
+
+    private:
+        Napi::Value GetSize(const Napi::CallbackInfo& info);
+        Napi::Value GetType(const Napi::CallbackInfo& info);
+        Napi::Value Text(const Napi::CallbackInfo& info);
+        Napi::Value ArrayBuffer(const Napi::CallbackInfo& info);
+        Napi::Value Bytes(const Napi::CallbackInfo& info);
+
+        Napi::ArrayBuffer CreateArrayBuffer() const;
+        void ProcessBlobPart(const Napi::Value& blobPart);
+
+        std::vector<uint8_t> m_data;
+        std::string m_type;
+    };
+}

--- a/Polyfills/Blob/Source/Blob.h
+++ b/Polyfills/Blob/Source/Blob.h
@@ -21,7 +21,6 @@ namespace Babylon::Polyfills::Internal
         Napi::Value ArrayBuffer(const Napi::CallbackInfo& info);
         Napi::Value Bytes(const Napi::CallbackInfo& info);
 
-        Napi::ArrayBuffer CreateArrayBuffer() const;
         void ProcessBlobPart(const Napi::Value& blobPart);
 
         std::vector<uint8_t> m_data;

--- a/Polyfills/CMakeLists.txt
+++ b/Polyfills/CMakeLists.txt
@@ -21,3 +21,7 @@ endif()
 if(JSRUNTIMEHOST_POLYFILL_WEBSOCKET)
     add_subdirectory(WebSocket)
 endif()
+
+if(JSRUNTIMEHOST_POLYFILL_BLOB)
+    add_subdirectory(Blob)
+endif()

--- a/Tests/UnitTests/Android/app/src/main/cpp/CMakeLists.txt
+++ b/Tests/UnitTests/Android/app/src/main/cpp/CMakeLists.txt
@@ -37,4 +37,5 @@ target_link_libraries(UnitTestsJNI
     PRIVATE UrlLib
     PRIVATE XMLHttpRequest
     PRIVATE WebSocket
-    PRIVATE gtest_main)
+    PRIVATE gtest_main
+    PRIVATE Blob)

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(UnitTests
     PRIVATE WebSocket
     PRIVATE gtest_main
     PRIVATE Foundation
+    PRIVATE Blob
     ${ADDITIONAL_LIBRARIES})
 
 # See https://gitlab.kitware.com/cmake/cmake/-/issues/23543

--- a/Tests/UnitTests/Scripts/tests.js
+++ b/Tests/UnitTests/Scripts/tests.js
@@ -728,30 +728,23 @@ describe("Console", function () {
 });
 
 describe("Blob", function () {
-    let emptyBlob, stringBlob, uint8Blob, arrayBufferBlob, nestedBlob, utf8Blob, lineEndingsBlob;
-    let mimeBlobs = {};
+    let emptyBlobs, helloBlobs, stringBlob, typedArrayBlob, arrayBufferBlob, blobBlob;
 
     before(function () {
-        emptyBlob = new Blob();
+        emptyBlobs = [new Blob(), new Blob([])];
         stringBlob = new Blob(["Hello"]);
-        uint8Blob = new Blob([new Uint8Array([72, 101, 108, 108, 111])]);
-        arrayBufferBlob = new Blob([new Uint8Array([72, 101, 108, 108, 111]).buffer]);
-        nestedBlob = new Blob([stringBlob]);
-        utf8Blob = new Blob(["你好, 世界"]); // "Hello, World" in Chinese
-        lineEndingsBlob = new Blob(["Hello\nWorld"]);
-
-        mimeBlobs = {
-            textPlain: new Blob(["some data"], { type: "text/plain" }),
-            applicationJson: new Blob(["some data"], { type: "application/json" }),
-            modelGltfBinary: new Blob(["some data"], { type: "model/gltf-binary" }),
-            modelGltfJson: new Blob(["some data"], { type: "model/gltf+json" })
-        };
+        typedArrayBlob = new Blob([new Uint8Array([72, 101, 108, 108, 111])]),
+        arrayBufferBlob = new Blob([new Uint8Array([72, 101, 108, 108, 111]).buffer]),
+        blobBlob = new Blob([new Blob(["Hello"])]),
+        helloBlobs = [stringBlob, typedArrayBlob, arrayBufferBlob, blobBlob]
     });
 
     // -------------------------------- Blob Construction --------------------------------
-    it("creates empty blob with correct defaults", function () {
-        expect(emptyBlob.size).to.equal(0);
-        expect(emptyBlob.type).to.equal("");
+    it("creates empty blobs", function () {
+        for (const blob of emptyBlobs) {
+            expect(blob.size).to.equal(0);
+            expect(blob.type).to.equal("");
+        }
     });
 
     it("creates blob from string array", function () {
@@ -759,78 +752,92 @@ describe("Blob", function () {
         expect(stringBlob.type).to.equal("");
     });
 
-    it("creates blob from Uint8Array", function () {
-        expect(uint8Blob.size).to.equal(5);
+    it("creates blob from TypedArray", function () {
+        expect(typedArrayBlob.size).to.equal(5);
+        expect(typedArrayBlob.type).to.equal("");
     });
 
     it("creates blob from ArrayBuffer", function () {
         expect(arrayBufferBlob.size).to.equal(5);
+        expect(arrayBufferBlob.type).to.equal("");
     });
 
     it("creates blob from another Blob", function () {
-        expect(nestedBlob.size).to.equal(stringBlob.size);
+        expect(blobBlob.size).to.equal(5);
+        expect(blobBlob.type).to.equal("");
     });
 
     it("applies MIME type from options", function () {
-        expect(mimeBlobs.textPlain.type).to.equal("text/plain");
-    });
-
-    it("supports various MIME types", function () {
-        expect(mimeBlobs.applicationJson.type).to.equal("application/json");
-        expect(mimeBlobs.modelGltfBinary.type).to.equal("model/gltf-binary");
-        expect(mimeBlobs.modelGltfJson.type).to.equal("model/gltf+json");
+        const modelGltfJson = new Blob(["glTF"], { type: "model/gltf+json" })
+        expect(modelGltfJson.type).to.equal("model/gltf+json");
     });
 
     // -------------------------------- Blob.text() --------------------------------
-    it("returns empty string for empty blob", async function () {
-        const text = await emptyBlob.text();
-        expect(text).to.equal("");
+    it("returns empty string for empty blobs", async function () {
+        for (const blob of emptyBlobs) {
+            const text = await blob.text();
+            expect(text).to.equal("");
+        }
     });
 
-    it("returns correct string content", async function () {
-        const text = await stringBlob.text();
-        expect(text).to.equal("Hello");
+    it("returns correct string content for non-empty blobs", async function () {
+        for (const blob of helloBlobs) {
+            const text = await blob.text();
+            expect(text).to.equal("Hello");
+        }
     });
 
     it("handles multi-byte UTF-8 characters", async function () {
+        const utf8Blob = new Blob(["你好, 世界"]);
         const text = await utf8Blob.text();
         expect(text).to.equal("你好, 世界");
     });
 
     it("preserves line endings like default transparent mode", async function () {
-        expect(lineEndingsBlob.size).to.equal(11);
-
+        const lineEndingsBlob = new Blob(["Hello\nWorld"]);
         const text = await lineEndingsBlob.text();
         expect(text).to.equal("Hello\nWorld");
     });
 
-    // -------------------------------- Blob.arrayBuffer() --------------------------------
-    it("returns empty buffer for empty blob", async function () {
-        const buffer = await emptyBlob.arrayBuffer();
-        expect(buffer.byteLength).to.equal(0);
-    });
-
-    it("returns correct buffer content", async function () {
-        const buffer = await stringBlob.arrayBuffer();
-
-        expect(buffer.byteLength).to.equal(5);
-        const view = new Uint8Array(buffer);
-        expect(view[0]).to.equal(72); // 'H'
-        expect(view[4]).to.equal(111); // 'o'
-    });
-
     // -------------------------------- Blob.bytes() --------------------------------
-    it("returns empty Uint8Array for empty blob", async function () {
-        const bytes = await emptyBlob.bytes();
-        expect(bytes.length).to.equal(0);
+    it("returns empty Uint8Array for empty blobs", async function () {
+        for (const blob of emptyBlobs) {
+            const bytes = await blob.bytes();
+            expect(bytes).to.be.instanceOf(Uint8Array);
+            expect(bytes.length).to.equal(0);
+        }
     });
 
-    it("returns correct Uint8Array content", async function () {
-        const bytes = await stringBlob.bytes();
+    it("returns correct byte content from non-empty blobs", async function () {
+        for (const blob of helloBlobs) {
+            const bytes = await blob.bytes();
+            expect(bytes).to.be.instanceOf(Uint8Array);
+            expect(bytes.length).to.equal(5);
+            expect(bytes[0]).to.equal(72); // 'H'
+            expect(bytes[4]).to.equal(111); // 'o'
+        }
+    });
 
-        expect(bytes.length).to.equal(5);
-        expect(bytes[0]).to.equal(72); // 'H'
-        expect(bytes[4]).to.equal(111); // 'o'
+    // -------------------------------- Blob.arrayBuffer() --------------------------------
+    it("returns empty buffer for empty blobs", async function () {
+        for (const blob of emptyBlobs) {
+            const buffer = await blob.arrayBuffer();
+            expect(buffer).to.be.instanceOf(ArrayBuffer);
+            expect(buffer.byteLength).to.equal(0);
+        }
+    });
+
+    it("returns correct buffer content for non-empty blobs", async function () {
+        for (const blob of helloBlobs) {
+            const buffer = await blob.arrayBuffer();
+            expect(buffer).to.be.instanceOf(ArrayBuffer);
+            expect(buffer.byteLength).to.equal(5);
+
+            const view = new Uint8Array(buffer);
+            expect(view[0]).to.equal(72); // 'H'
+            expect(view[4]).to.equal(111); // 'o'
+
+        }
     });
 });
 

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -7,6 +7,7 @@
 #include <Babylon/Polyfills/URL.h>
 #include <Babylon/Polyfills/WebSocket.h>
 #include <Babylon/Polyfills/XMLHttpRequest.h>
+#include <Babylon/Polyfills/Blob.h>
 #include <gtest/gtest.h>
 #include <future>
 #include <iostream>
@@ -64,6 +65,7 @@ TEST(JavaScript, All)
         Babylon::Polyfills::URL::Initialize(env);
         Babylon::Polyfills::WebSocket::Initialize(env);
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
+        Babylon::Polyfills::Blob::Initialize(env);
 
         auto setExitCodeCallback = Napi::Function::New(
             env, [&exitCodePromise](const Napi::CallbackInfo& info) {


### PR DESCRIPTION
Polyfilling the [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) interface, sans the following methods:
- `stream()`
- `splice()`
- `options.ending`

and the following behaviors:
- Sanitizing `options.type`. Instead, the given MIME type is expected to already be ASCII-encoded and in lower case.
- Processing any blobParts past `blobParts[0]`. 
- UTF-8 decoding in `text()`.