### PR TITLE
Small inclusion fix for <exception>

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "exception": "cpp"
-    }
-}


### PR DESCRIPTION
The file napi.h uses std::exception and std::exception_ptr. However, it does not include the <exception> header. This normally get taken care by other includes, but it can cause compiler errors depending on include order for consuming applications. 