### PR TITLE
Incremental steps to support Android XR

### DIFF
--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorAgent.cpp
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorAgent.cpp
@@ -426,8 +426,8 @@ namespace Babylon
         }
         v8::Local<v8::String> string_value = v8::Local<v8::String>::Cast(value);
         int len = string_value->Length();
-        std::basic_string<uint16_t> buffer(len, '\0');
-        string_value->Write(v8::Isolate::GetCurrent(), &buffer[0], 0, len);
+        std::vector<uint16_t> buffer(len, 0);
+        string_value->Write(v8::Isolate::GetCurrent(), buffer.data(), 0, len);
         return v8_inspector::StringBuffer::create(
             v8_inspector::StringView(buffer.data(), len));
     }

--- a/Core/Node-API/CMakeLists.txt
+++ b/Core/Node-API/CMakeLists.txt
@@ -88,15 +88,44 @@ if(NAPI_BUILD_ABI)
             "Source/js_native_api_v8_internals.h")
 
         if(ANDROID)
-            set(V8_PACKAGE_NAME "v8-android-jit-nointl-nosnapshot")
-            set(V8_ANDROID_DIR "${CMAKE_CURRENT_BINARY_DIR}/${V8_PACKAGE_NAME}")
-            napi_install_android_package(v8 "dist/org/chromium" ${V8_ANDROID_DIR})
+            if(NOT V8_ANDROID_INCLUDE_DIR)
+                find_path(V8_ANDROID_INCLUDE_DIR
+                    NAMES v8.h
+                    HINTS
+                        "${CMAKE_SYSROOT}/usr/include"
+                        "${CMAKE_SYSROOT}/usr/local/include"
+                    PATH_SUFFIXES
+                        v8
+                        include/v8)
+            endif()
+
+            if(NOT V8_ANDROID_INCLUDE_DIR)
+                message(FATAL_ERROR "Unable to locate V8 headers for Android. Set V8_ANDROID_INCLUDE_DIR to the directory containing v8.h.")
+            endif()
+
+            if(NOT V8_ANDROID_LIBRARY)
+                find_library(V8_ANDROID_LIBRARY
+                    NAMES v8android
+                    HINTS
+                        "${CMAKE_SYSROOT}/usr/lib/${ANDROID_ABI}"
+                        "${CMAKE_SYSROOT}/usr/lib"
+                        "${CMAKE_SYSROOT}/usr/lib64"
+                        "${CMAKE_SYSROOT}/usr/lib32"
+                        "${CMAKE_SYSROOT}/system/lib"
+                        "${CMAKE_SYSROOT}/system/lib64"
+                        "${CMAKE_SYSROOT}/apex/com.android.vndk.current/lib"
+                        "${CMAKE_SYSROOT}/apex/com.android.vndk.current/lib64")
+            endif()
+
+            if(NOT V8_ANDROID_LIBRARY)
+                message(FATAL_ERROR "Unable to locate the system libv8android.so. Set V8_ANDROID_LIBRARY to the path of the library.")
+            endif()
 
             set(INCLUDE_DIRECTORIES ${INCLUDE_DIRECTORIES}
-                PUBLIC "${V8_ANDROID_DIR}/include")
+                PUBLIC "${V8_ANDROID_INCLUDE_DIR}")
 
             set(LINK_LIBRARIES ${LINK_LIBRARIES}
-                PUBLIC "${V8_ANDROID_DIR}/jni/${ANDROID_ABI}/libv8android.so")
+                PUBLIC "${V8_ANDROID_LIBRARY}")
         elseif(WIN32)
             set_cpu_platform_arch()
             set(V8_VERSION "11.9.169.4")

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install
 _Follow the steps from [All Development Platforms](#all-development-platforms) before proceeding._
 
 **Required Tools:**
-[Android Studio](https://developer.android.com/studio), [Node.js](https://nodejs.org/en/download/), [Ninja](https://ninja-build.org/)
+[Android Studio](https://developer.android.com/studio) (with Android NDK 28.0.12674087 and API level 34 SDK platforms installed), [Node.js](https://nodejs.org/en/download/), [Ninja](https://ninja-build.org/)
 
 The minimal requirement target is Android 5.0.
 

--- a/Tests/UnitTests/Android/app/build.gradle
+++ b/Tests/UnitTests/Android/app/build.gradle
@@ -9,8 +9,8 @@ if (project.hasProperty("jsEngine")) {
 
 android {
     namespace 'com.jsruntimehost.unittests'
-    compileSdk 33
-    ndkVersion = "23.1.7779620"
+    compileSdk 34
+    ndkVersion = "28.0.12674087"
     if (project.hasProperty("ndkVersion")) {
         ndkVersion = project.property("ndkVersion")
     }
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         applicationId "com.jsruntimehost.unittests"
         minSdk 21
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
Bump the NDK just below unstable r29 and SDK API level 36 that appear to be necessary for building for Android XR devices. 

This also makes sure that we are using the OS-installed v8, rather than building from a separate source, so that profile-optimized system version that received security updates keeps apps performant. The performance aspect is key for 3D/XR workloads, and the security aspect is key when BabylonJS is processing user-supplied data by opening and rendering splats, behavior graphs, WGSL shaders, etc.

The C++20 incompatibility highlighted by newer clang in NDK 28 was highlighted by a similar downstream PR in BabylonNative: https://github.com/BabylonJS/BabylonNative/pull/1552