### PR TITLE
Add EXCLUDE_FROM_ALL to fetch content deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,28 +9,36 @@ include(FetchContent)
 # --------------------------------------------------
 # Declarations
 # --------------------------------------------------
-FetchContent_Declare(arcana.cpp
-    GIT_REPOSITORY https://github.com/microsoft/arcana.cpp.git
-    GIT_TAG c02527c32d51b6b3ffeda36f8cf140d2e1c60bb9)
 FetchContent_Declare(AndroidExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/AndroidExtensions.git
-    GIT_TAG f7ed149b5360cc8a4908fece66607c5ce1e6095b)
+    GIT_TAG f7ed149b5360cc8a4908fece66607c5ce1e6095b
+    EXCLUDE_FROM_ALL)
+FetchContent_Declare(arcana.cpp
+    GIT_REPOSITORY https://github.com/microsoft/arcana.cpp.git
+    GIT_TAG c02527c32d51b6b3ffeda36f8cf140d2e1c60bb9
+    EXCLUDE_FROM_ALL)
 FetchContent_Declare(asio
     GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
-    GIT_TAG f693a3eb7fe72a5f19b975289afc4f437d373d9c)
+    GIT_TAG f693a3eb7fe72a5f19b975289afc4f437d373d9c
+    EXCLUDE_FROM_ALL)
 FetchContent_Declare(CMakeExtensions
     GIT_REPOSITORY https://github.com/BabylonJS/CMakeExtensions.git
-    GIT_TAG ea28b7689530bfdc4905806f27ecf7e8ed4b5419)
+    GIT_TAG ea28b7689530bfdc4905806f27ecf7e8ed4b5419
+    EXCLUDE_FROM_ALL)
 FetchContent_Declare(googletest
-    URL "https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz")
+    URL "https://github.com/google/googletest/archive/refs/tags/v1.17.0.tar.gz"
+    EXCLUDE_FROM_ALL)
 FetchContent_Declare(ios-cmake
     GIT_REPOSITORY https://github.com/leetal/ios-cmake.git
-    GIT_TAG 4.4.1)
+    GIT_TAG 4.4.1
+    EXCLUDE_FROM_ALL)
 FetchContent_Declare(llhttp
-    URL "https://github.com/nodejs/llhttp/archive/refs/tags/release/v8.1.0.tar.gz")
+    URL "https://github.com/nodejs/llhttp/archive/refs/tags/release/v8.1.0.tar.gz"
+    EXCLUDE_FROM_ALL)
 FetchContent_Declare(UrlLib
     GIT_REPOSITORY https://github.com/BabylonJS/UrlLib.git
-    GIT_TAG 1f9d2c05f792d994b09fdfc1129b25294efbe182)
+    GIT_TAG 1f9d2c05f792d994b09fdfc1129b25294efbe182
+    EXCLUDE_FROM_ALL)
 # --------------------------------------------------
 
 FetchContent_MakeAvailable(CMakeExtensions)


### PR DESCRIPTION
Similar to https://github.com/BabylonJS/BabylonNative/pull/1579. This change will make building V8 cleaner because it brings in `llhttp` which has extra install files we don't need.