### PR TITLE
Fix performance test flake on CI

### DIFF
--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -46,10 +46,6 @@ endif()
 add_executable(UnitTests ${SOURCES} ${SCRIPTS} ${TYPE_SCRIPTS} ${ASSETS})
 target_compile_definitions(UnitTests PRIVATE JSRUNTIMEHOST_PLATFORM="${JSRUNTIMEHOST_PLATFORM}")
 
-if(ENABLE_SANITIZERS)
-    target_compile_definitions(UnitTests PRIVATE JSRUNTIMEHOST_SANITIZERS_ENABLED=1)
-endif()
-
 target_link_libraries(UnitTests
     PRIVATE AppRuntime
     PRIVATE Console

--- a/Tests/UnitTests/Scripts/tests.ts
+++ b/Tests/UnitTests/Scripts/tests.ts
@@ -7,7 +7,6 @@ Mocha.reporter('spec');
 
 declare const hostPlatform: string;
 declare const setExitCode: (code: number) => void;
-declare const sanitizersEnabled: boolean;
 
 
 describe("AbortController", function () {
@@ -1235,11 +1234,11 @@ describe("Performance", function () {
     it("should measure elapsed time accurately", function (done) {
         const start = performance.now();
         const delay = 50;
-        const tolerance = sanitizersEnabled ? 500 : 100;
         setTimeout(() => {
             const elapsed = performance.now() - start;
+            // setTimeout guarantees a minimum delay, not a maximum.
+            // Only check the lower bound to avoid flakes on busy CI agents.
             expect(elapsed).to.be.at.least(delay - 5);
-            expect(elapsed).to.be.lessThan(delay + tolerance);
             done();
         }, delay);
     });

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -84,12 +84,6 @@ TEST(JavaScript, All)
         env.Global().Set("setExitCode", setExitCodeCallback);
 
         env.Global().Set("hostPlatform", Napi::Value::From(env, JSRUNTIMEHOST_PLATFORM));
-
-#ifdef JSRUNTIMEHOST_SANITIZERS_ENABLED
-        env.Global().Set("sanitizersEnabled", Napi::Value::From(env, true));
-#else
-        env.Global().Set("sanitizersEnabled", Napi::Value::From(env, false));
-#endif
     });
 
     Babylon::ScriptLoader loader{runtime};


### PR DESCRIPTION
Fix flaky `should measure elapsed time accurately` test on CI.

## The Bug

`setTimeout` only guarantees a minimum delay, not a maximum. On busy CI agents (especially macOS), the callback can fire well beyond the 100ms tolerance window, causing `assertBelow` to fail.

## The Fix

Remove the upper-bound assertion — only verify that elapsed time is at least the requested delay. The test still validates that `performance.now()` returns accurate, monotonically increasing values.

Also removes the now-unused `sanitizersEnabled` plumbing (CMake define, C++ global, TS declaration) since this was its only consumer.
