### PR TITLE
Fix: Make arcana a PUBLIC dependency of AppRuntime

### DIFF
--- a/Core/AppRuntime/CMakeLists.txt
+++ b/Core/AppRuntime/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(AppRuntime
     INTERFACE "Include")
 
 target_link_libraries(AppRuntime
-    PRIVATE arcana
+    PUBLIC arcana
     PUBLIC JsRuntime)
 
 if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8" AND JSRUNTIMEHOST_CORE_APPRUNTIME_V8_INSPECTOR)


### PR DESCRIPTION
Make arcana a PUBLIC dependency of AppRuntime.

## The Bug

`AppRuntime.h` includes `arcana/threading/cancellation.h` and `arcana/threading/dispatcher.h`, but AppRuntime linked arcana as `PRIVATE`. Consumers of AppRuntime (like BabylonNative's UnitTests) didn't get arcana's include directories, causing build failures.

## Root Cause

PR #149 (Merge WorkQueue into AppRuntime) moved arcana includes into the public `AppRuntime.h` header. The link visibility should have been updated to `PUBLIC` at the same time.

## The Fix

Change `PRIVATE arcana` to `PUBLIC arcana` in `Core/AppRuntime/CMakeLists.txt`.
