### PR TITLE
Update package-lock.json

### DIFF
--- a/Tests/package-lock.json
+++ b/Tests/package-lock.json
@@ -3380,6 +3380,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

Update `package-lock.json` to include resolved optional dependencies.

`npm install` was regenerating the lock file on every run because `fsevents` (an optional macOS dependency) was missing. This caused spurious diffs when working locally.
