### PR TITLE
Increase iOS CI timeout to 45 minutes

### DIFF
--- a/.github/jobs/ios.yml
+++ b/.github/jobs/ios.yml
@@ -6,7 +6,7 @@ parameters:
 
 jobs:
 - job: ${{parameters.name}}
-  timeoutInMinutes: 30
+  timeoutInMinutes: 45
 
   pool:
     vmImage: ${{parameters.vmImage}}


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

Increase iOS CI job timeout from 30 to 45 minutes.

iOS_Xcode152 builds regularly take 20-30 minutes with high variability depending on CI pool contention during business hours. The 30-minute timeout was causing cancellations on slower runs.

Recent timing data (different agents each time):

| Duration | Agent | Time |
|----------|-------|------|
| 29.3min | Agent 15 | daytime |
| 12.4min | Agent 15 | overnight |
| 26.4min | Agent 13 | overnight |
| 19.3min | Agent 7 | evening |
| 16.1min | Agent 11 | evening |

45 minutes provides headroom while still catching actual hangs.
