### PR TITLE
Repro: issue #131 invalid-server WebSocket flake (DO NOT MERGE)

### DIFF
--- a/Tests/UnitTests/Scripts/tests.ts
+++ b/Tests/UnitTests/Scripts/tests.ts
@@ -526,13 +526,18 @@ if (hostPlatform !== "Unix") {
             };
         });
 
-        // TODO: This is not working reliably: see https://github.com/BabylonJS/JsRuntimeHost/issues/131
-        // it("should trigger error callback with invalid server", function (done) {
-        //     const ws = new WebSocket("wss://caddddfd-ee88-4771-b293-8a8e13b330ee.com");
-        //     ws.onerror = () => {
-        //         done();
-        //     };
-        // });
+        // Repro for https://github.com/BabylonJS/JsRuntimeHost/issues/131
+        // Issue reports ~1/3 flake rate. Running 20 iterations so that if the
+        // flake still exists, P(all pass) = (2/3)^20 ≈ 0.03%.
+        for (let i = 1; i <= 20; i++) {
+            it(`should trigger error callback with invalid server (iter ${i})`, function (done) {
+                this.timeout(15000);
+                const ws = new WebSocket("wss://caddddfd-ee88-4771-b293-8a8e13b330ee.com");
+                ws.onerror = () => {
+                    done();
+                };
+            });
+        }
 
         it("should trigger error callback with invalid domain", function (done) {
             this.timeout(10000);


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

**Do not merge.** This is a CI repro branch for https://github.com/BabylonJS/JsRuntimeHost/issues/131.

## Purpose

Issue #131 reports that the "should trigger error callback with invalid server" WebSocket test fails ~1/3 of the time. The test was commented out in #130. Since filing, the following WebSocket-related changes landed on `main`:

- #150 — Fix WebSocket test flake and update UrlLib (pulls in UrlLib #26 which consolidated `onError`/`onClose` dispatch on Windows + Apple).
- #160 — Fix WebSocket polyfill `close()`/`send()` spec compliance.
- (UrlLib #27 — Apple TSan fixes, not yet pulled in.)

Running the suite 30× locally on Windows + Chakra (at pre-#150 and at pre-#160 snapshots) produced **0 failures**, so the flake is not reproducible on Windows locally. This PR uncomments the test and runs **20 iterations** of it so CI (Linux/macOS) has a high probability of catching the flake if it still exists: P(all pass) = (2/3)^20 ≈ 0.03% if the 1/3 flake rate still holds.

## Expected outcome

- If CI goes green → our WebSocket changes (#150 / #160) likely fixed the issue; we can close #131 and keep the real test re-enabled (in a follow-up PR).
- If CI fails → the original flake persists; we keep the test commented out and continue investigating in UrlLib / per-platform impls.

## Not for merge

This PR adds 20 copies of the same test (spam), which is not an acceptable final state. If the repro confirms the fix, a follow-up PR will restore just the original single test.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
