### PR TITLE
Add Xcode 26 CI jobs and drop Xcode 15.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,12 @@ jobs:
       runs-on: macos-latest
       enable-thread-sanitizer: true
 
+  macOS_Xcode26:
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      xcode-version: '26.4'
+      runs-on: macos-26
+
 
   # ── iOS ───────────────────────────────────────────────────────
   iOS_Xcode164:
@@ -99,12 +105,12 @@ jobs:
       runs-on: macos-latest
       simulator: 'iPhone 16'
 
-  iOS_Xcode152:
+  iOS_Xcode26:
     uses: ./.github/workflows/build-ios.yml
     with:
-      xcode-version: '15.2'
-      runs-on: macos-14
-      simulator: 'iPhone 15'
+      xcode-version: '26.4'
+      runs-on: macos-26
+      simulator: 'iPhone 17'
 
   # ── Linux ─────────────────────────────────────────────────────
   Ubuntu_gcc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       runs-on: macos-latest
       enable-thread-sanitizer: true
 
-  macOS_Xcode26:
+  macOS_Xcode264:
     uses: ./.github/workflows/build-macos.yml
     with:
       xcode-version: '26.4'
@@ -105,7 +105,7 @@ jobs:
       runs-on: macos-latest
       simulator: 'iPhone 16'
 
-  iOS_Xcode26:
+  iOS_Xcode264:
     uses: ./.github/workflows/build-ios.yml
     with:
       xcode-version: '26.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,19 @@ jobs:
       xcode-version: '26.4'
       runs-on: macos-26
 
+  macOS_Xcode264_Sanitizers:
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      xcode-version: '26.4'
+      runs-on: macos-26
+      enable-sanitizers: true
+
+  macOS_Xcode264_ThreadSanitizer:
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      xcode-version: '26.4'
+      runs-on: macos-26
+      enable-thread-sanitizer: true
 
   # ── iOS ───────────────────────────────────────────────────────
   iOS_Xcode164:


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

Add CI coverage for Xcode 26 (`macos-26` runner) and drop Xcode 15.2.

## Changes

- **Added** `macOS_Xcode264` — builds + tests on `macos-26` with Xcode 26.4.
- **Added** `macOS_Xcode264_Sanitizers` — ASan/UBSan on `macos-26` with Xcode 26.4.
- **Added** `macOS_Xcode264_ThreadSanitizer` — TSan on `macos-26` with Xcode 26.4.
- **Added** `iOS_Xcode264` — builds + tests on `macos-26` with Xcode 26.4, iPhone 17 simulator.
- **Removed** `iOS_Xcode152` — the `macos-14` runner and Xcode 15.2 are on their way to being retired; Xcode 16.4 (`macos-latest`) is our baseline and Xcode 26 now exercises the latest toolchain.

The Xcode 16.4 sanitizer jobs are retained alongside the new 26.4 sanitizer jobs. Major Xcode bumps have historically introduced sanitizer-runtime regressions (instrumentation gaps as the toolchain catches up to new system libraries), and TSan on arm64 is less battle-tested than on x86. Running both lets us catch regressions on the newer toolchain without losing coverage if Xcode 26 has sanitizer issues. Once Xcode 26 sanitizers have been stable for a while, the 16.4 sanitizer jobs can be dropped.

Mirrors the approach taken in BabylonJS/BabylonNative#1642. No source changes were needed — JsRuntimeHost has no iOS/macOS UI code (no `UIScreen.mainScreen`, `connectedScenes`, or `statusBarOrientation` usages), so the iOS 26 deprecations addressed in #1642 don't apply here.

## Dropping Xcode 15.2

Xcode 15.2 coverage came from the `macos-14` runner, which is being phased out on GitHub Actions. With `macos-latest` pinned to Xcode 16.4 and the new `macos-26` job exercising Xcode 26.4, the 15.2 slot is redundant and unsupported.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
