### PR TITLE
Add JS callstack to console.error callback

### DIFF
--- a/Polyfills/Console/Include/Babylon/Polyfills/Console.h
+++ b/Polyfills/Console/Include/Babylon/Polyfills/Console.h
@@ -17,6 +17,13 @@ namespace Babylon::Polyfills::Console
         Error,
     };
 
+    /**
+     * Callback invoked for each `console.log` / `console.warn` / `console.error` call.
+     *
+     * The `const char*` message is the formatted message produced by joining the call arguments
+     * (like browsers do). Its storage is only valid for the duration of the callback -- copy if
+     * you need to retain it. The `LogLevel` indicates which `console.*` method was invoked.
+     */
     using CallbackT = std::function<void BABYLON_API (const char*, LogLevel)>;
 
     void BABYLON_API Initialize(Napi::Env env, CallbackT callback);
@@ -29,8 +36,10 @@ namespace Babylon::Polyfills::Console
      * `console.*` call. The polyfill's own shim frame(s) are skipped, so the top frame is the
      * user's call site.
      *
-     * Format is engine-defined opaque text -- treat as diagnostic-only, do not parse. Returns an
-     * empty string if no JS context is active or if stack capture fails for any reason.
+     * Format is engine-defined opaque text -- treat as diagnostic-only, do not parse. Capture is
+     * **best-effort**: returns an empty string if no JS context is active, the engine doesn't
+     * expose a `stack` property on `Error`, or any internal operation fails. Hosts must check
+     * for an empty result before using the value.
      *
      * Cost is non-trivial (currently implemented via `new Error().stack` under the hood); the
      * caller decides per-message whether to invoke. Hosts that want stacks only on error

--- a/Polyfills/Console/Include/Babylon/Polyfills/Console.h
+++ b/Polyfills/Console/Include/Babylon/Polyfills/Console.h
@@ -3,6 +3,8 @@
 #include <napi/env.h>
 #include <Babylon/Api.h>
 
+#include <string>
+
 namespace Babylon::Polyfills::Console
 {
     /**
@@ -15,17 +17,25 @@ namespace Babylon::Polyfills::Console
         Error,
     };
 
-    /**
-     * Called for each `console.log` / `console.warn` / `console.error` invocation.
-     *
-     * @param message   Formatted message produced by joining the call arguments (like browsers do).
-     * @param logLevel  Importance of the message.
-     * @param jsStack   For `LogLevel::Error`, the JavaScript callstack captured at the
-     *                  `console.error` call site (raw `Error.stack` string -- the format is engine-
-     *                  defined and typically starts with the literal `Error\n`). Empty string for
-     *                  `Log` and `Warn` (capturing a stack on every `console.log` is too expensive).
-     */
-    using CallbackT = std::function<void BABYLON_API (const char* message, LogLevel logLevel, const char* jsStack)>;
+    using CallbackT = std::function<void BABYLON_API (const char*, LogLevel)>;
 
     void BABYLON_API Initialize(Napi::Env env, CallbackT callback);
+
+    /**
+     * Capture the JavaScript callstack at the current JS execution point.
+     *
+     * Only meaningful when called from within a `CallbackT` invocation (or any other Napi callback
+     * the polyfill itself registered) -- captures the JS frames that produced the originating
+     * `console.*` call. The polyfill's own shim frame(s) are skipped, so the top frame is the
+     * user's call site.
+     *
+     * Format is engine-defined opaque text -- treat as diagnostic-only, do not parse. Returns an
+     * empty string if no JS context is active or if stack capture fails for any reason.
+     *
+     * Cost is non-trivial (currently implemented via `new Error().stack` under the hood); the
+     * caller decides per-message whether to invoke. Hosts that want stacks only on error
+     * messages can branch on `LogLevel`; hosts that want them everywhere are free to do so;
+     * hosts that don't care pay nothing.
+     */
+    std::string BABYLON_API CaptureCurrentJsStack(Napi::Env env);
 }

--- a/Polyfills/Console/Include/Babylon/Polyfills/Console.h
+++ b/Polyfills/Console/Include/Babylon/Polyfills/Console.h
@@ -15,7 +15,17 @@ namespace Babylon::Polyfills::Console
         Error,
     };
 
-    using CallbackT = std::function<void BABYLON_API (const char*, LogLevel)>;
+    /**
+     * Called for each `console.log` / `console.warn` / `console.error` invocation.
+     *
+     * @param message   Formatted message produced by joining the call arguments (like browsers do).
+     * @param logLevel  Importance of the message.
+     * @param jsStack   For `LogLevel::Error`, the JavaScript callstack captured at the
+     *                  `console.error` call site (raw `Error.stack` string -- the format is engine-
+     *                  defined and typically starts with the literal `Error\n`). Empty string for
+     *                  `Log` and `Warn` (capturing a stack on every `console.log` is too expensive).
+     */
+    using CallbackT = std::function<void BABYLON_API (const char* message, LogLevel logLevel, const char* jsStack)>;
 
     void BABYLON_API Initialize(Napi::Env env, CallbackT callback);
 }

--- a/Polyfills/Console/Readme.md
+++ b/Polyfills/Console/Readme.md
@@ -6,9 +6,12 @@ Currently supports:
 * `warn()`
 * `error()`
 
-When initializing, you should provide a callback which takes a message and a log level and outputs the message in whatever way you like. For example, you could initialize it like so:
+When initializing, you should provide a callback which takes a message, a log level, and a JS callstack and outputs the message in whatever way you like. The callstack is captured at the call site for `error()` calls (raw `Error.stack`, engine-defined format -- typically starting with a literal `Error\n` line); it is an empty string for `log()` and `warn()` calls (capturing a stack on every `console.log` would be too costly). For example, you could initialize it like so:
 ```c++
-Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
+Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto, const char* jsStack) {
     fprintf(stdout, "%s", message);
+    if (jsStack[0] != '\0') {
+        fprintf(stdout, "\n%s", jsStack);
+    }
     fflush(stdout);
 });

--- a/Polyfills/Console/Readme.md
+++ b/Polyfills/Console/Readme.md
@@ -14,7 +14,7 @@ Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
 });
 ```
 
-Inside the callback you can optionally capture the JavaScript callstack at the originating `console.*` call site via `Babylon::Polyfills::Console::CaptureCurrentJsStack(env)`. The polyfill's own shim frames are skipped, so the top frame is the user's call site. The capture is opt-in per-call -- hosts that don't need stacks pay nothing; hosts that want them on a specific level can branch on the `LogLevel` argument:
+Inside the callback you can optionally capture the JavaScript callstack at the originating `console.*` call site via `Babylon::Polyfills::Console::CaptureCurrentJsStack(env)`. The polyfill's own shim frames are skipped, so the top frame is the user's call site. Capture is best-effort -- the returned string can be empty (no JS context active, engine doesn't expose `Error.stack`, etc.), so always check before using. The capture is opt-in per-call -- hosts that don't need stacks pay nothing; hosts that want them on a specific level can branch on the `LogLevel` argument:
 ```c++
 Babylon::Polyfills::Console::Initialize(env, [env](const char* message, auto level) {
     fprintf(stdout, "%s", message);

--- a/Polyfills/Console/Readme.md
+++ b/Polyfills/Console/Readme.md
@@ -6,12 +6,24 @@ Currently supports:
 * `warn()`
 * `error()`
 
-When initializing, you should provide a callback which takes a message, a log level, and a JS callstack and outputs the message in whatever way you like. The callstack is captured at the call site for `error()` calls (raw `Error.stack`, engine-defined format -- typically starting with a literal `Error\n` line); it is an empty string for `log()` and `warn()` calls (capturing a stack on every `console.log` would be too costly). For example, you could initialize it like so:
+When initializing, you should provide a callback which takes a message and a log level and outputs the message in whatever way you like. For example, you could initialize it like so:
 ```c++
-Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto, const char* jsStack) {
+Babylon::Polyfills::Console::Initialize(env, [](const char* message, auto) {
     fprintf(stdout, "%s", message);
-    if (jsStack[0] != '\0') {
-        fprintf(stdout, "\n%s", jsStack);
+    fflush(stdout);
+});
+```
+
+Inside the callback you can optionally capture the JavaScript callstack at the originating `console.*` call site via `Babylon::Polyfills::Console::CaptureCurrentJsStack(env)`. The polyfill's own shim frames are skipped, so the top frame is the user's call site. The capture is opt-in per-call -- hosts that don't need stacks pay nothing; hosts that want them on a specific level can branch on the `LogLevel` argument:
+```c++
+Babylon::Polyfills::Console::Initialize(env, [env](const char* message, auto level) {
+    fprintf(stdout, "%s", message);
+    if (level == Babylon::Polyfills::Console::LogLevel::Error) {
+        auto stack = Babylon::Polyfills::Console::CaptureCurrentJsStack(env);
+        if (!stack.empty()) {
+            fprintf(stdout, "\n%s", stack.c_str());
+        }
     }
     fflush(stdout);
 });
+```

--- a/Polyfills/Console/Source/Console.cpp
+++ b/Polyfills/Console/Source/Console.cpp
@@ -102,34 +102,7 @@ namespace
             }
         }
 
-        std::string jsStack{};
-        if (logLevel == Babylon::Polyfills::Console::LogLevel::Error)
-        {
-            // Capture the JS callstack at the `console.error` call site. We construct a JS `Error`
-            // object via N-API which fills its `stack` property using the engine's current JS frames;
-            // the topmost real frame is the user's `console.error(...)` callsite (the Napi-wrapped
-            // function we registered does not add a visible JS frame on V8/JSC/Chakra). Best effort;
-            // any failure leaves `jsStack` empty.
-            try
-            {
-                Napi::Env env = info.Env();
-                Napi::Value errorCtorValue = env.Global().Get("Error");
-                if (errorCtorValue.IsFunction())
-                {
-                    Napi::Object errObj = errorCtorValue.As<Napi::Function>().New({}).As<Napi::Object>();
-                    Napi::Value stackValue = errObj.Get("stack");
-                    if (stackValue.IsString())
-                    {
-                        jsStack = stackValue.As<Napi::String>().Utf8Value();
-                    }
-                }
-            }
-            catch (...)
-            {
-            }
-        }
-
-        callback(ss.str().c_str(), logLevel, jsStack.c_str());
+        callback(ss.str().c_str(), logLevel);
     }
 
     void AddMethod(Napi::Object& console, const char* functionName, Babylon::Polyfills::Console::LogLevel logLevel, Babylon::Polyfills::Console::CallbackT callback)
@@ -165,5 +138,33 @@ namespace Babylon::Polyfills::Console
         AddMethod(console, "log", LogLevel::Log, callback);
         AddMethod(console, "warn", LogLevel::Warn, callback);
         AddMethod(console, "error", LogLevel::Error, callback);
+    }
+
+    std::string BABYLON_API CaptureCurrentJsStack(Napi::Env env)
+    {
+        // Construct a JS `Error` object via N-API which fills its `stack` property using the
+        // engine's current JS frames; on every backend we support (V8 / JSC / ChakraCore) the
+        // resulting string omits the C++ Napi wrapper frame, so the topmost JS frame is the
+        // user's call site. Best effort -- any failure (no `Error` global, engine doesn't expose
+        // a `stack` property, etc.) returns an empty string.
+        std::string stack{};
+        try
+        {
+            Napi::HandleScope scope{env};
+            Napi::Value errorCtorValue = env.Global().Get("Error");
+            if (errorCtorValue.IsFunction())
+            {
+                Napi::Object errObj = errorCtorValue.As<Napi::Function>().New({}).As<Napi::Object>();
+                Napi::Value stackValue = errObj.Get("stack");
+                if (stackValue.IsString())
+                {
+                    stack = stackValue.As<Napi::String>().Utf8Value();
+                }
+            }
+        }
+        catch (...)
+        {
+        }
+        return stack;
     }
 }

--- a/Polyfills/Console/Source/Console.cpp
+++ b/Polyfills/Console/Source/Console.cpp
@@ -102,7 +102,34 @@ namespace
             }
         }
 
-        callback(ss.str().c_str(), logLevel);
+        std::string jsStack{};
+        if (logLevel == Babylon::Polyfills::Console::LogLevel::Error)
+        {
+            // Capture the JS callstack at the `console.error` call site. We construct a JS `Error`
+            // object via N-API which fills its `stack` property using the engine's current JS frames;
+            // the topmost real frame is the user's `console.error(...)` callsite (the Napi-wrapped
+            // function we registered does not add a visible JS frame on V8/JSC/Chakra). Best effort;
+            // any failure leaves `jsStack` empty.
+            try
+            {
+                Napi::Env env = info.Env();
+                Napi::Value errorCtorValue = env.Global().Get("Error");
+                if (errorCtorValue.IsFunction())
+                {
+                    Napi::Object errObj = errorCtorValue.As<Napi::Function>().New({}).As<Napi::Object>();
+                    Napi::Value stackValue = errObj.Get("stack");
+                    if (stackValue.IsString())
+                    {
+                        jsStack = stackValue.As<Napi::String>().Utf8Value();
+                    }
+                }
+            }
+            catch (...)
+            {
+            }
+        }
+
+        callback(ss.str().c_str(), logLevel, jsStack.c_str());
     }
 
     void AddMethod(Napi::Object& console, const char* functionName, Babylon::Polyfills::Console::LogLevel logLevel, Babylon::Polyfills::Console::CallbackT callback)

--- a/Polyfills/Console/Source/Console.cpp
+++ b/Polyfills/Console/Source/Console.cpp
@@ -165,6 +165,16 @@ namespace Babylon::Polyfills::Console
         catch (...)
         {
         }
+
+        // N-API operations can leave a pending JS exception on `env` independently of throwing a
+        // C++ exception (e.g., `Object::Get` on a property accessor that throws); returning from
+        // the callback with a pending exception would cause `console.*` itself to throw on the
+        // JS side. Clear it so stack capture is truly side-effect free.
+        if (env.IsExceptionPending())
+        {
+            (void)env.GetAndClearPendingException();
+        }
+
         return stack;
     }
 }

--- a/Polyfills/Console/Source/Console.cpp
+++ b/Polyfills/Console/Source/Console.cpp
@@ -154,7 +154,7 @@ namespace Babylon::Polyfills::Console
             Napi::Value errorCtorValue = env.Global().Get("Error");
             if (errorCtorValue.IsFunction())
             {
-                Napi::Object errObj = errorCtorValue.As<Napi::Function>().New({}).As<Napi::Object>();
+                Napi::Object errObj = errorCtorValue.As<Napi::Function>().New({});
                 Napi::Value stackValue = errObj.Get("stack");
                 if (stackValue.IsString())
                 {

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -61,8 +61,13 @@ TEST(JavaScript, All)
     Babylon::AppRuntime runtime{options};
 
     runtime.Dispatch([&exitCodePromise](Napi::Env env) mutable {
-        Babylon::Polyfills::Console::Initialize(env, [](const char* message, Babylon::Polyfills::Console::LogLevel logLevel) {
-            std::cout << "[" << EnumToString(logLevel) << "] " << message << std::endl;
+        Babylon::Polyfills::Console::Initialize(env, [](const char* message, Babylon::Polyfills::Console::LogLevel logLevel, const char* jsStack) {
+            std::cout << "[" << EnumToString(logLevel) << "] " << message;
+            if (logLevel == Babylon::Polyfills::Console::LogLevel::Error && jsStack != nullptr && jsStack[0] != '\0')
+            {
+                std::cout << std::endl << jsStack;
+            }
+            std::cout << std::endl;
             std::cout.flush();
         });
 
@@ -100,7 +105,7 @@ TEST(Console, Log)
     Babylon::AppRuntime runtime{};
 
     runtime.Dispatch([](Napi::Env env) mutable {
-        Babylon::Polyfills::Console::Initialize(env, [](const char* message, Babylon::Polyfills::Console::LogLevel logLevel) {
+        Babylon::Polyfills::Console::Initialize(env, [](const char* message, Babylon::Polyfills::Console::LogLevel logLevel, const char* /*jsStack*/) {
             const char* test = "foo bar";
             if (strcmp(message, test) != 0)
             {
@@ -121,6 +126,40 @@ TEST(Console, Log)
     });
 
     done.get_future().get();
+}
+
+TEST(Console, ErrorProvidesJsStack)
+{
+    // Regression: console.error must invoke the callback with a non-empty jsStack containing
+    // the JS call site. console.log / console.warn must be empty (stack capture is skipped for
+    // hot paths).
+    Babylon::AppRuntime runtime{};
+
+    std::promise<std::string> errorStackPromise;
+    std::promise<std::string> logStackPromise;
+
+    runtime.Dispatch([&errorStackPromise, &logStackPromise](Napi::Env env) mutable {
+        Babylon::Polyfills::Console::Initialize(env, [&](const char* /*message*/, Babylon::Polyfills::Console::LogLevel logLevel, const char* jsStack) {
+            if (logLevel == Babylon::Polyfills::Console::LogLevel::Error)
+            {
+                errorStackPromise.set_value(jsStack ? jsStack : "");
+            }
+            else if (logLevel == Babylon::Polyfills::Console::LogLevel::Log)
+            {
+                logStackPromise.set_value(jsStack ? jsStack : "");
+            }
+        });
+    });
+
+    Babylon::ScriptLoader loader{runtime};
+    loader.Eval("console.log('log message');", "");
+    loader.Eval("function inner() { console.error('error message'); } inner();", "");
+
+    std::string errorStack = errorStackPromise.get_future().get();
+    std::string logStack = logStackPromise.get_future().get();
+
+    EXPECT_TRUE(logStack.empty()) << "Log path should not capture a stack; got: " << logStack;
+    EXPECT_FALSE(errorStack.empty()) << "Error path must provide a non-empty jsStack";
 }
 
 TEST(AppRuntime, DestroyDoesNotDeadlock)

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -160,8 +160,16 @@ TEST(Console, CaptureCurrentJsStack)
     loader.Eval("console.log('log message');", "");
     loader.Eval("function inner() { console.error('error message'); } inner();", "");
 
-    std::string errorStack = errorStackPromise.get_future().get();
-    std::string logStack = logStackPromise.get_future().get();
+    auto errorFuture = errorStackPromise.get_future();
+    auto logFuture = logStackPromise.get_future();
+    constexpr auto timeout = std::chrono::seconds(30);
+    ASSERT_EQ(errorFuture.wait_for(timeout), std::future_status::ready)
+        << "console.error callback did not fire within timeout";
+    ASSERT_EQ(logFuture.wait_for(timeout), std::future_status::ready)
+        << "console.log callback did not fire within timeout";
+
+    std::string errorStack = errorFuture.get();
+    std::string logStack = logFuture.get();
 
     EXPECT_FALSE(errorStack.empty()) << "console.error path must capture a non-empty JS stack";
     EXPECT_FALSE(logStack.empty()) << "console.log path must capture a non-empty JS stack";

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -61,11 +61,15 @@ TEST(JavaScript, All)
     Babylon::AppRuntime runtime{options};
 
     runtime.Dispatch([&exitCodePromise](Napi::Env env) mutable {
-        Babylon::Polyfills::Console::Initialize(env, [](const char* message, Babylon::Polyfills::Console::LogLevel logLevel, const char* jsStack) {
+        Babylon::Polyfills::Console::Initialize(env, [env](const char* message, Babylon::Polyfills::Console::LogLevel logLevel) {
             std::cout << "[" << EnumToString(logLevel) << "] " << message;
-            if (logLevel == Babylon::Polyfills::Console::LogLevel::Error && jsStack != nullptr && jsStack[0] != '\0')
+            if (logLevel == Babylon::Polyfills::Console::LogLevel::Error)
             {
-                std::cout << std::endl << jsStack;
+                std::string stack = Babylon::Polyfills::Console::CaptureCurrentJsStack(env);
+                if (!stack.empty())
+                {
+                    std::cout << std::endl << stack;
+                }
             }
             std::cout << std::endl;
             std::cout.flush();
@@ -105,7 +109,7 @@ TEST(Console, Log)
     Babylon::AppRuntime runtime{};
 
     runtime.Dispatch([](Napi::Env env) mutable {
-        Babylon::Polyfills::Console::Initialize(env, [](const char* message, Babylon::Polyfills::Console::LogLevel logLevel, const char* /*jsStack*/) {
+        Babylon::Polyfills::Console::Initialize(env, [](const char* message, Babylon::Polyfills::Console::LogLevel logLevel) {
             const char* test = "foo bar";
             if (strcmp(message, test) != 0)
             {
@@ -128,25 +132,26 @@ TEST(Console, Log)
     done.get_future().get();
 }
 
-TEST(Console, ErrorProvidesJsStack)
+TEST(Console, CaptureCurrentJsStack)
 {
-    // Regression: console.error must invoke the callback with a non-empty jsStack containing
-    // the JS call site. console.log / console.warn must be empty (stack capture is skipped for
-    // hot paths).
+    // Regression: Console::CaptureCurrentJsStack must return a non-empty stack when called from
+    // within a callback fired by `console.error`, and when called from `console.log` (any frame
+    // produced by JS execution). When called with no JS context active it should return empty.
     Babylon::AppRuntime runtime{};
 
     std::promise<std::string> errorStackPromise;
     std::promise<std::string> logStackPromise;
 
     runtime.Dispatch([&errorStackPromise, &logStackPromise](Napi::Env env) mutable {
-        Babylon::Polyfills::Console::Initialize(env, [&](const char* /*message*/, Babylon::Polyfills::Console::LogLevel logLevel, const char* jsStack) {
+        Babylon::Polyfills::Console::Initialize(env, [env, &errorStackPromise, &logStackPromise](const char* /*message*/, Babylon::Polyfills::Console::LogLevel logLevel) {
+            std::string stack = Babylon::Polyfills::Console::CaptureCurrentJsStack(env);
             if (logLevel == Babylon::Polyfills::Console::LogLevel::Error)
             {
-                errorStackPromise.set_value(jsStack ? jsStack : "");
+                errorStackPromise.set_value(std::move(stack));
             }
             else if (logLevel == Babylon::Polyfills::Console::LogLevel::Log)
             {
-                logStackPromise.set_value(jsStack ? jsStack : "");
+                logStackPromise.set_value(std::move(stack));
             }
         });
     });
@@ -158,8 +163,8 @@ TEST(Console, ErrorProvidesJsStack)
     std::string errorStack = errorStackPromise.get_future().get();
     std::string logStack = logStackPromise.get_future().get();
 
-    EXPECT_TRUE(logStack.empty()) << "Log path should not capture a stack; got: " << logStack;
-    EXPECT_FALSE(errorStack.empty()) << "Error path must provide a non-empty jsStack";
+    EXPECT_FALSE(errorStack.empty()) << "console.error path must capture a non-empty JS stack";
+    EXPECT_FALSE(logStack.empty()) << "console.log path must capture a non-empty JS stack";
 }
 
 TEST(AppRuntime, DestroyDoesNotDeadlock)

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -136,7 +136,7 @@ TEST(Console, CaptureCurrentJsStack)
 {
     // Regression: Console::CaptureCurrentJsStack must return a non-empty stack when called from
     // within a callback fired by `console.error`, and when called from `console.log` (any frame
-    // produced by JS execution). When called with no JS context active it should return empty.
+    // produced by JS execution).
     Babylon::AppRuntime runtime{};
 
     std::promise<std::string> errorStackPromise;


### PR DESCRIPTION
## Problem

Host applications consuming JsRuntimeHost have no way to associate a `console.error(...)` (or any other `console.*`) call with the JavaScript call site that produced it. The `Console::CallbackT` signature only delivers the formatted message and the log level. To get a JS stack today, hosts must monkey-patch `console.error` from JavaScript (`new Error().stack`, push as extra arg, call original) -- which both pollutes the global `console` object and masks the real call site under one or two synthetic frames.

## Fix

Add an additive helper:

```cpp
namespace Babylon::Polyfills::Console
{
    using CallbackT = std::function<void BABYLON_API (const char*, LogLevel)>;
    void BABYLON_API Initialize(Napi::Env env, CallbackT callback);
    std::string BABYLON_API CaptureCurrentJsStack(Napi::Env env);
}
```

Hosts opt in by calling `CaptureCurrentJsStack(env)` inside their existing 2-arg `CallbackT`. The polyfill's own shim frames are skipped, so the top frame is the user's call site.

```cpp
Babylon::Polyfills::Console::Initialize(env, [env](const char* message, auto level) {
    fprintf(stdout, "%s", message);
    if (level == Babylon::Polyfills::Console::LogLevel::Error) {
        auto stack = Babylon::Polyfills::Console::CaptureCurrentJsStack(env);
        if (!stack.empty()) {
            fprintf(stdout, "\n%s", stack.c_str());
        }
    }
    fflush(stdout);
});
```

The format of the returned string is engine-defined opaque text -- consumers should treat it as diagnostic-only and not parse.

## Why a helper instead of a third `CallbackT` parameter

The first iteration of this PR added a 3rd `const char* jsStack` parameter to `CallbackT`. Reviewer feedback (#166 review thread) rightly pointed out three problems with that approach:

1. **Breaking API change.** Every existing host with an `Initialize(env, [](msg, lvl){ ... })` lambda would have to update.
2. **Always-on cost.** `new Error()` + stack format + UTF-8 conversion would run on every `console.error` even when the host doesn't use the parameter.
3. **Unnecessary.** When `CallbackT` fires, the JS frames that produced the `console.*` call are still alive on the JS stack -- the engine is paused mid-call, one or two C++ transition layers behind. The host can capture from inside the existing 2-arg callback.

The helper-based design fixes all three:

- **Non-breaking.** Every existing 2-arg `CallbackT` continues to compile and behave identically. Hosts that don't care about stacks need not change a line.
- **No always-on cost.** `new Error().stack` runs only when the host invokes the helper -- per-call, per-level, per-call-site, fully host-controlled.
- **Frame-skip count is an implementation detail** of the polyfill (the engine `new Error()` capture skips the Napi wrapper frame already). Hosts don't need to know it.

Internally the helper is currently implemented via N-API `new Error().stack`; when a cheap N-API stack-capture primitive lands later, the body can be swapped without touching the public API.

## Tests

New `Console.CaptureCurrentJsStack` gtest in `Tests/UnitTests/Shared/Shared.cpp`: registers a 2-arg `CallbackT` that calls `CaptureCurrentJsStack(env)` inside its body, asserts both `console.error` and `console.log` paths yield a non-empty stack.

## In-tree consumer updates

- `Tests/UnitTests/Shared/Shared.cpp` -- both `Console::Initialize` lambdas use the helper.
- `Polyfills/Console/Readme.md` -- documents the helper alongside the existing `Initialize` example.