### PR TITLE
Bump UrlLib pin to include client-side-failure fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ FetchContent_Declare(llhttp
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(UrlLib
     GIT_REPOSITORY https://github.com/BabylonJS/UrlLib.git
-    GIT_TAG d251ad44015e1ee6cd071514cb863d8ffc220f16
+    GIT_TAG 16c7dfd88cb5e7121cb5b037b44b796b737955d4
     EXCLUDE_FROM_ALL)
 # --------------------------------------------------
 


### PR DESCRIPTION
Picks up [UrlLib #28](https://github.com/BabylonJS/UrlLib/pull/28) so consumers (including BabylonNative) get the client-side-failure fixes:

- `ImplBase::ResetForOpen()` clears `m_statusCode`, `m_responseUrl`, `m_responseString`, `m_headers` between `Open()` calls on all 5 platforms (Win32, UWP, Unix, Apple, Android).
- Unix `PerformAsync` no longer lets `curl_check` exceptions escape `std::thread` -> `std::terminate`; falls back to `status=0 + loadend` like Win32/UWP.
- Apple `Open` no longer throws synchronously when `[NSBundle pathForResource:]` returns nil for missing local files; sets `m_url = nil` and lets the existing `SendAsync` branch return `status=0`.

This is a pin-bump only: no source changes in JsRuntimeHost itself.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>