### PR TITLE
Add TextEncoder polyfill (WHATWG Encoding Standard)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ option(JSRUNTIMEHOST_POLYFILL_WEBSOCKET "Include JsRuntimeHost Polyfill WebSocke
 option(JSRUNTIMEHOST_POLYFILL_BLOB "Include JsRuntimeHost Polyfill Blob." ON)
 option(JSRUNTIMEHOST_POLYFILL_PERFORMANCE "Include JsRuntimeHost Polyfill Performance." ON)
 option(JSRUNTIMEHOST_POLYFILL_TEXTDECODER "Include JsRuntimeHost Polyfill TextDecoder." ON)
+option(JSRUNTIMEHOST_POLYFILL_TEXTENCODER "Include JsRuntimeHost Polyfill TextEncoder." ON)
 
 # Sanitizers
 option(ENABLE_SANITIZERS "Enable AddressSanitizer and UBSan" OFF)

--- a/Polyfills/CMakeLists.txt
+++ b/Polyfills/CMakeLists.txt
@@ -33,3 +33,7 @@ endif()
 if(JSRUNTIMEHOST_POLYFILL_TEXTDECODER)
     add_subdirectory(TextDecoder)
 endif()
+
+if(JSRUNTIMEHOST_POLYFILL_TEXTENCODER)
+    add_subdirectory(TextEncoder)
+endif()

--- a/Polyfills/TextEncoder/CMakeLists.txt
+++ b/Polyfills/TextEncoder/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(SOURCES
+    "Include/Babylon/Polyfills/TextEncoder.h"
+    "Source/TextEncoder.cpp")
+
+add_library(TextEncoder ${SOURCES})
+warnings_as_errors(TextEncoder)
+
+target_include_directories(TextEncoder PUBLIC "Include")
+
+target_link_libraries(TextEncoder
+    PUBLIC napi
+    PUBLIC Foundation)
+
+set_property(TARGET TextEncoder PROPERTY FOLDER Polyfills)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})

--- a/Polyfills/TextEncoder/Include/Babylon/Polyfills/TextEncoder.h
+++ b/Polyfills/TextEncoder/Include/Babylon/Polyfills/TextEncoder.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <napi/env.h>
+#include <Babylon/Api.h>
+
+namespace Babylon::Polyfills::TextEncoder
+{
+    void BABYLON_API Initialize(Napi::Env env);
+}

--- a/Polyfills/TextEncoder/README.md
+++ b/Polyfills/TextEncoder/README.md
@@ -1,0 +1,33 @@
+# TextEncoder Polyfill
+
+A C++ implementation of the [WHATWG Encoding API](https://encoding.spec.whatwg.org/) `TextEncoder` interface for use in Babylon Native JavaScript runtimes via [Napi](https://github.com/nodejs/node-addon-api).
+
+This is the encoding counterpart to the `TextDecoder` polyfill in this same repository. Both polyfills exist primarily for older Chakra-based runtimes where the WHATWG Encoding Standard globals are not built in. On modern V8 / JSC / Hermes runtimes the constructor is already exposed and `Initialize()` is a no-op.
+
+## Current State
+
+### Supported
+
+- Constructing `TextEncoder` with no argument (UTF-8 is the only encoding the spec mandates).
+- The `encoding` accessor (always returns `"utf-8"`).
+- `encode(input)` — returns a `Uint8Array` containing the UTF-8 bytes of `input`. Calling with no argument or `undefined` returns an empty `Uint8Array` (matches the spec, which defaults `input` to `""`).
+- `encodeInto(source, destination)` — writes UTF-8 bytes of `source` into the caller-provided `Uint8Array` and returns `{ read, written }`. `read` is the number of UTF-16 code units consumed from `source` (4-byte UTF-8 sequences count as 2 because they correspond to a surrogate pair); multi-byte sequences are never split across the destination boundary.
+
+### Not Supported
+
+- Encodings other than UTF-8 — the `TextEncoder` constructor in the spec only accepts UTF-8 anyway, so this is not a deviation.
+- `encodeInto` requires the destination to be a `Uint8Array` (passing any other typed array throws a `TypeError`).
+
+## Usage
+
+```javascript
+const encoder = new TextEncoder();
+encoder.encoding;                              // "utf-8"
+
+encoder.encode("Hello");                       // Uint8Array(5) [72,101,108,108,111]
+encoder.encode();                              // Uint8Array(0) []
+
+const dst = new Uint8Array(8);
+encoder.encodeInto("Hi", dst);                 // { read: 2, written: 2 }
+encoder.encodeInto("\u{1F600}", dst);          // { read: 2, written: 4 } (surrogate pair, 4-byte UTF-8)
+```

--- a/Polyfills/TextEncoder/README.md
+++ b/Polyfills/TextEncoder/README.md
@@ -11,23 +11,18 @@ This is the encoding counterpart to the `TextDecoder` polyfill in this same repo
 - Constructing `TextEncoder` with no argument (UTF-8 is the only encoding the spec mandates).
 - The `encoding` accessor (always returns `"utf-8"`).
 - `encode(input)` — returns a `Uint8Array` containing the UTF-8 bytes of `input`. Calling with no argument or `undefined` returns an empty `Uint8Array` (matches the spec, which defaults `input` to `""`).
-- `encodeInto(source, destination)` — writes UTF-8 bytes of `source` into the caller-provided `Uint8Array` and returns `{ read, written }`. `read` is the number of UTF-16 code units consumed from `source` (4-byte UTF-8 sequences count as 2 because they correspond to a surrogate pair); multi-byte sequences are never split across the destination boundary.
 
 ### Not Supported
 
 - Encodings other than UTF-8 — the `TextEncoder` constructor in the spec only accepts UTF-8 anyway, so this is not a deviation.
-- `encodeInto` requires the destination to be a `Uint8Array` (passing any other typed array throws a `TypeError`).
+- `encodeInto(source, destination)` — not implemented. Babylon.js does not call this entry point; the (substantially more involved) UTF-16-code-unit accounting it would require is not justified by any current consumer. If a future consumer needs it, it can be added at that time.
 
 ## Usage
 
 ```javascript
 const encoder = new TextEncoder();
-encoder.encoding;                              // "utf-8"
+encoder.encoding;                 // "utf-8"
 
-encoder.encode("Hello");                       // Uint8Array(5) [72,101,108,108,111]
-encoder.encode();                              // Uint8Array(0) []
-
-const dst = new Uint8Array(8);
-encoder.encodeInto("Hi", dst);                 // { read: 2, written: 2 }
-encoder.encodeInto("\u{1F600}", dst);          // { read: 2, written: 4 } (surrogate pair, 4-byte UTF-8)
+encoder.encode("Hello");          // Uint8Array(5) [72,101,108,108,111]
+encoder.encode();                 // Uint8Array(0) []
 ```

--- a/Polyfills/TextEncoder/Source/TextEncoder.cpp
+++ b/Polyfills/TextEncoder/Source/TextEncoder.cpp
@@ -1,0 +1,153 @@
+#include <Babylon/Polyfills/TextEncoder.h>
+
+#include <napi/napi.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace
+{
+    // Number of UTF-16 code units that the given (validated) UTF-8 leading byte
+    // represents. Returns 0 for a continuation byte. A 4-byte UTF-8 sequence
+    // encodes a code point outside the BMP, which corresponds to a surrogate
+    // pair in UTF-16 (2 code units); everything else is 1 code unit.
+    inline uint32_t Utf8LeadingByteToCodeUnits(uint8_t b)
+    {
+        if ((b & 0x80u) == 0u)     return 1; // ASCII
+        if ((b & 0xE0u) == 0xC0u)  return 1; // 2-byte sequence
+        if ((b & 0xF0u) == 0xE0u)  return 1; // 3-byte sequence
+        if ((b & 0xF8u) == 0xF0u)  return 2; // 4-byte sequence -> surrogate pair
+        return 0;                            // continuation or invalid
+    }
+
+    inline size_t Utf8SequenceLength(uint8_t b)
+    {
+        if ((b & 0x80u) == 0u)     return 1;
+        if ((b & 0xE0u) == 0xC0u)  return 2;
+        if ((b & 0xF0u) == 0xE0u)  return 3;
+        if ((b & 0xF8u) == 0xF0u)  return 4;
+        return 1;
+    }
+
+    class TextEncoder final : public Napi::ObjectWrap<TextEncoder>
+    {
+    public:
+        static void Initialize(Napi::Env env)
+        {
+            Napi::HandleScope scope{env};
+
+            static constexpr auto JS_TEXTENCODER_CONSTRUCTOR_NAME = "TextEncoder";
+            if (env.Global().Get(JS_TEXTENCODER_CONSTRUCTOR_NAME).IsUndefined())
+            {
+                Napi::Function func = DefineClass(
+                    env,
+                    JS_TEXTENCODER_CONSTRUCTOR_NAME,
+                    {
+                        InstanceAccessor("encoding", &TextEncoder::Encoding, nullptr),
+                        InstanceMethod("encode", &TextEncoder::Encode),
+                        InstanceMethod("encodeInto", &TextEncoder::EncodeInto),
+                    });
+
+                env.Global().Set(JS_TEXTENCODER_CONSTRUCTOR_NAME, func);
+            }
+        }
+
+        explicit TextEncoder(const Napi::CallbackInfo& info)
+            : Napi::ObjectWrap<TextEncoder>{info}
+        {
+            // The TextEncoder constructor takes no arguments. The encoding is
+            // always UTF-8 per the WHATWG Encoding Standard.
+        }
+
+    private:
+        Napi::Value Encoding(const Napi::CallbackInfo& info)
+        {
+            return Napi::String::New(info.Env(), "utf-8");
+        }
+
+        // Coerce arg 0 to a std::string of UTF-8 bytes. Per spec, undefined
+        // input defaults to the empty string (not "undefined").
+        static std::string InputAsUtf8(const Napi::CallbackInfo& info)
+        {
+            if (info.Length() < 1 || info[0].IsUndefined())
+            {
+                return {};
+            }
+            return info[0].ToString().Utf8Value();
+        }
+
+        // encode(input = "") - returns a Uint8Array containing the UTF-8 bytes.
+        Napi::Value Encode(const Napi::CallbackInfo& info)
+        {
+            auto env = info.Env();
+            auto utf8 = InputAsUtf8(info);
+
+            auto bytes = Napi::Uint8Array::New(env, utf8.size());
+            if (!utf8.empty())
+            {
+                std::memcpy(bytes.Data(), utf8.data(), utf8.size());
+            }
+            return bytes;
+        }
+
+        // encodeInto(source, destination) - writes UTF-8 bytes into a caller-
+        // provided Uint8Array and returns { read, written }. Per the WHATWG
+        // Encoding Standard, "read" is the number of UTF-16 code units consumed
+        // from `source` and multi-byte sequences are never split.
+        Napi::Value EncodeInto(const Napi::CallbackInfo& info)
+        {
+            auto env = info.Env();
+            if (info.Length() < 2 || !info[1].IsTypedArray())
+            {
+                throw Napi::TypeError::New(env, "TextEncoder.encodeInto: destination must be a Uint8Array");
+            }
+            auto dest = info[1].As<Napi::Uint8Array>();
+
+            auto utf8 = InputAsUtf8(info);
+
+            // Walk forward through the UTF-8 bytes one code-point sequence at a
+            // time, stopping when the next sequence would not fit. This keeps
+            // multi-byte sequences atomic and lets us derive an accurate UTF-16
+            // "read" count without ever building a separate UTF-16 string.
+            size_t writeOffset = 0;
+            uint32_t readCodeUnits = 0;
+            const size_t capacity = dest.ByteLength();
+            const uint8_t* src = reinterpret_cast<const uint8_t*>(utf8.data());
+
+            for (size_t i = 0; i < utf8.size();)
+            {
+                size_t seqLen = Utf8SequenceLength(src[i]);
+                if (i + seqLen > utf8.size())
+                {
+                    break;
+                }
+                if (writeOffset + seqLen > capacity)
+                {
+                    break;
+                }
+                readCodeUnits += Utf8LeadingByteToCodeUnits(src[i]);
+                writeOffset += seqLen;
+                i += seqLen;
+            }
+
+            if (writeOffset > 0)
+            {
+                std::memcpy(dest.Data(), utf8.data(), writeOffset);
+            }
+
+            auto result = Napi::Object::New(env);
+            result.Set("read", Napi::Number::New(env, static_cast<double>(readCodeUnits)));
+            result.Set("written", Napi::Number::New(env, static_cast<double>(writeOffset)));
+            return result;
+        }
+    };
+}
+
+namespace Babylon::Polyfills::TextEncoder
+{
+    void BABYLON_API Initialize(Napi::Env env)
+    {
+        ::TextEncoder::Initialize(env);
+    }
+}

--- a/Polyfills/TextEncoder/Source/TextEncoder.cpp
+++ b/Polyfills/TextEncoder/Source/TextEncoder.cpp
@@ -2,34 +2,11 @@
 
 #include <napi/napi.h>
 
-#include <cstdint>
 #include <cstring>
 #include <string>
 
 namespace
 {
-    // Number of UTF-16 code units that the given (validated) UTF-8 leading byte
-    // represents. Returns 0 for a continuation byte. A 4-byte UTF-8 sequence
-    // encodes a code point outside the BMP, which corresponds to a surrogate
-    // pair in UTF-16 (2 code units); everything else is 1 code unit.
-    inline uint32_t Utf8LeadingByteToCodeUnits(uint8_t b)
-    {
-        if ((b & 0x80u) == 0u)     return 1; // ASCII
-        if ((b & 0xE0u) == 0xC0u)  return 1; // 2-byte sequence
-        if ((b & 0xF0u) == 0xE0u)  return 1; // 3-byte sequence
-        if ((b & 0xF8u) == 0xF0u)  return 2; // 4-byte sequence -> surrogate pair
-        return 0;                            // continuation or invalid
-    }
-
-    inline size_t Utf8SequenceLength(uint8_t b)
-    {
-        if ((b & 0x80u) == 0u)     return 1;
-        if ((b & 0xE0u) == 0xC0u)  return 2;
-        if ((b & 0xF0u) == 0xE0u)  return 3;
-        if ((b & 0xF8u) == 0xF0u)  return 4;
-        return 1;
-    }
-
     class TextEncoder final : public Napi::ObjectWrap<TextEncoder>
     {
     public:
@@ -46,7 +23,6 @@ namespace
                     {
                         InstanceAccessor("encoding", &TextEncoder::Encoding, nullptr),
                         InstanceMethod("encode", &TextEncoder::Encode),
-                        InstanceMethod("encodeInto", &TextEncoder::EncodeInto),
                     });
 
                 env.Global().Set(JS_TEXTENCODER_CONSTRUCTOR_NAME, func);
@@ -66,22 +42,16 @@ namespace
             return Napi::String::New(info.Env(), "utf-8");
         }
 
-        // Coerce arg 0 to a std::string of UTF-8 bytes. Per spec, undefined
-        // input defaults to the empty string (not "undefined").
-        static std::string InputAsUtf8(const Napi::CallbackInfo& info)
-        {
-            if (info.Length() < 1 || info[0].IsUndefined())
-            {
-                return {};
-            }
-            return info[0].ToString().Utf8Value();
-        }
-
         // encode(input = "") - returns a Uint8Array containing the UTF-8 bytes.
+        // Per spec, undefined input defaults to the empty string (not "undefined").
         Napi::Value Encode(const Napi::CallbackInfo& info)
         {
             auto env = info.Env();
-            auto utf8 = InputAsUtf8(info);
+            std::string utf8;
+            if (info.Length() > 0 && !info[0].IsUndefined())
+            {
+                utf8 = info[0].ToString().Utf8Value();
+            }
 
             auto bytes = Napi::Uint8Array::New(env, utf8.size());
             if (!utf8.empty())
@@ -89,57 +59,6 @@ namespace
                 std::memcpy(bytes.Data(), utf8.data(), utf8.size());
             }
             return bytes;
-        }
-
-        // encodeInto(source, destination) - writes UTF-8 bytes into a caller-
-        // provided Uint8Array and returns { read, written }. Per the WHATWG
-        // Encoding Standard, "read" is the number of UTF-16 code units consumed
-        // from `source` and multi-byte sequences are never split.
-        Napi::Value EncodeInto(const Napi::CallbackInfo& info)
-        {
-            auto env = info.Env();
-            if (info.Length() < 2 || !info[1].IsTypedArray())
-            {
-                throw Napi::TypeError::New(env, "TextEncoder.encodeInto: destination must be a Uint8Array");
-            }
-            auto dest = info[1].As<Napi::Uint8Array>();
-
-            auto utf8 = InputAsUtf8(info);
-
-            // Walk forward through the UTF-8 bytes one code-point sequence at a
-            // time, stopping when the next sequence would not fit. This keeps
-            // multi-byte sequences atomic and lets us derive an accurate UTF-16
-            // "read" count without ever building a separate UTF-16 string.
-            size_t writeOffset = 0;
-            uint32_t readCodeUnits = 0;
-            const size_t capacity = dest.ByteLength();
-            const uint8_t* src = reinterpret_cast<const uint8_t*>(utf8.data());
-
-            for (size_t i = 0; i < utf8.size();)
-            {
-                size_t seqLen = Utf8SequenceLength(src[i]);
-                if (i + seqLen > utf8.size())
-                {
-                    break;
-                }
-                if (writeOffset + seqLen > capacity)
-                {
-                    break;
-                }
-                readCodeUnits += Utf8LeadingByteToCodeUnits(src[i]);
-                writeOffset += seqLen;
-                i += seqLen;
-            }
-
-            if (writeOffset > 0)
-            {
-                std::memcpy(dest.Data(), utf8.data(), writeOffset);
-            }
-
-            auto result = Napi::Object::New(env);
-            result.Set("read", Napi::Number::New(env, static_cast<double>(readCodeUnits)));
-            result.Set("written", Napi::Number::New(env, static_cast<double>(writeOffset)));
-            return result;
         }
     };
 }

--- a/Tests/UnitTests/Android/app/src/main/cpp/CMakeLists.txt
+++ b/Tests/UnitTests/Android/app/src/main/cpp/CMakeLists.txt
@@ -42,4 +42,5 @@ target_link_libraries(UnitTestsJNI
     PRIVATE gtest_main
     PRIVATE Blob
     PRIVATE TextDecoder
+    PRIVATE TextEncoder
     PRIVATE Performance)

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(UnitTests
     PRIVATE Blob
     PRIVATE Performance
     PRIVATE TextDecoder
+    PRIVATE TextEncoder
     ${ADDITIONAL_LIBRARIES})
 
 # See https://gitlab.kitware.com/cmake/cmake/-/issues/23543

--- a/Tests/UnitTests/Scripts/tests.ts
+++ b/Tests/UnitTests/Scripts/tests.ts
@@ -1356,6 +1356,81 @@ describe("TextDecoder", function () {
     });
 });
 
+describe("TextEncoder", function () {
+    it("should expose encoding === 'utf-8'", function () {
+        const encoder = new TextEncoder();
+        expect(encoder.encoding).to.equal("utf-8");
+    });
+
+    it("should encode an ASCII string into UTF-8 bytes", function () {
+        const encoder = new TextEncoder();
+        const bytes = encoder.encode("Hello");
+        expect(Array.from(bytes)).to.eql([72, 101, 108, 108, 111]);
+    });
+
+    it("should return an empty Uint8Array when called with no argument", function () {
+        const encoder = new TextEncoder();
+        const bytes = encoder.encode();
+        expect(bytes.length).to.equal(0);
+    });
+
+    it("should return an empty Uint8Array for undefined input", function () {
+        const encoder = new TextEncoder();
+        const bytes = encoder.encode(undefined);
+        expect(bytes.length).to.equal(0);
+    });
+
+    it("should encode a multi-byte UTF-8 string", function () {
+        const encoder = new TextEncoder();
+        // "é" is U+00E9 -> 0xC3 0xA9 in UTF-8
+        const bytes = encoder.encode("é");
+        expect(Array.from(bytes)).to.eql([0xC3, 0xA9]);
+    });
+
+    it("should encode a string containing a null byte", function () {
+        const encoder = new TextEncoder();
+        const bytes = encoder.encode("H\0i");
+        expect(Array.from(bytes)).to.eql([72, 0, 105]);
+    });
+
+    it("encodeInto should write UTF-8 bytes and return { read, written }", function () {
+        const encoder = new TextEncoder();
+        const dst = new Uint8Array(8);
+        const result = encoder.encodeInto("Hi", dst);
+        expect(result.read).to.equal(2);
+        expect(result.written).to.equal(2);
+        expect(dst[0]).to.equal(72);
+        expect(dst[1]).to.equal(105);
+    });
+
+    it("encodeInto should not split multi-byte sequences when destination is too small", function () {
+        const encoder = new TextEncoder();
+        // "aé" -> 0x61 0xC3 0xA9 (3 bytes). A 2-byte destination must hold 'a' but
+        // must NOT partially write the 2-byte 'é' sequence.
+        const dst = new Uint8Array(2);
+        const result = encoder.encodeInto("aé", dst);
+        expect(result.written).to.equal(1);
+        expect(result.read).to.equal(1);
+        expect(dst[0]).to.equal(0x61);
+        expect(dst[1]).to.equal(0);
+    });
+
+    it("encodeInto should report read as 2 for a code point outside the BMP", function () {
+        const encoder = new TextEncoder();
+        // U+1F600 -> 4-byte UTF-8 sequence; corresponds to a UTF-16 surrogate pair (2 code units).
+        const dst = new Uint8Array(8);
+        const result = encoder.encodeInto("\u{1F600}", dst);
+        expect(result.read).to.equal(2);
+        expect(result.written).to.equal(4);
+        expect(Array.from(dst.subarray(0, 4))).to.eql([0xF0, 0x9F, 0x98, 0x80]);
+    });
+
+    it("encodeInto should throw if destination is not a Uint8Array", function () {
+        const encoder = new TextEncoder();
+        expect(() => (encoder as any).encodeInto("x", "not a buffer")).to.throw(TypeError);
+    });
+});
+
 function runTests() {
     mocha.run((failures: number) => {
         // Test program will wait for code to be set before exiting

--- a/Tests/UnitTests/Scripts/tests.ts
+++ b/Tests/UnitTests/Scripts/tests.ts
@@ -1392,43 +1392,6 @@ describe("TextEncoder", function () {
         const bytes = encoder.encode("H\0i");
         expect(Array.from(bytes)).to.eql([72, 0, 105]);
     });
-
-    it("encodeInto should write UTF-8 bytes and return { read, written }", function () {
-        const encoder = new TextEncoder();
-        const dst = new Uint8Array(8);
-        const result = encoder.encodeInto("Hi", dst);
-        expect(result.read).to.equal(2);
-        expect(result.written).to.equal(2);
-        expect(dst[0]).to.equal(72);
-        expect(dst[1]).to.equal(105);
-    });
-
-    it("encodeInto should not split multi-byte sequences when destination is too small", function () {
-        const encoder = new TextEncoder();
-        // "aé" -> 0x61 0xC3 0xA9 (3 bytes). A 2-byte destination must hold 'a' but
-        // must NOT partially write the 2-byte 'é' sequence.
-        const dst = new Uint8Array(2);
-        const result = encoder.encodeInto("aé", dst);
-        expect(result.written).to.equal(1);
-        expect(result.read).to.equal(1);
-        expect(dst[0]).to.equal(0x61);
-        expect(dst[1]).to.equal(0);
-    });
-
-    it("encodeInto should report read as 2 for a code point outside the BMP", function () {
-        const encoder = new TextEncoder();
-        // U+1F600 -> 4-byte UTF-8 sequence; corresponds to a UTF-16 surrogate pair (2 code units).
-        const dst = new Uint8Array(8);
-        const result = encoder.encodeInto("\u{1F600}", dst);
-        expect(result.read).to.equal(2);
-        expect(result.written).to.equal(4);
-        expect(Array.from(dst.subarray(0, 4))).to.eql([0xF0, 0x9F, 0x98, 0x80]);
-    });
-
-    it("encodeInto should throw if destination is not a Uint8Array", function () {
-        const encoder = new TextEncoder();
-        expect(() => (encoder as any).encodeInto("x", "not a buffer")).to.throw(TypeError);
-    });
 });
 
 function runTests() {

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -10,6 +10,7 @@
 #include <Babylon/Polyfills/XMLHttpRequest.h>
 #include <Babylon/Polyfills/Blob.h>
 #include <Babylon/Polyfills/TextDecoder.h>
+#include <Babylon/Polyfills/TextEncoder.h>
 #include <gtest/gtest.h>
 #include <arcana/threading/blocking_concurrent_queue.h>
 #include <atomic>
@@ -83,6 +84,7 @@ TEST(JavaScript, All)
         Babylon::Polyfills::XMLHttpRequest::Initialize(env);
         Babylon::Polyfills::Blob::Initialize(env);
         Babylon::Polyfills::TextDecoder::Initialize(env);
+        Babylon::Polyfills::TextEncoder::Initialize(env);
 
         auto setExitCodeCallback = Napi::Function::New(
             env, [&exitCodePromise](const Napi::CallbackInfo& info) {


### PR DESCRIPTION
Adds a `TextEncoder` polyfill that mirrors the existing `TextDecoder` polyfill in this repository, so non-Babylon-Native consumers can get both halves of the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/) from `JsRuntimeHost` without having to pull in or duplicate a separate implementation.

`TextEncoder` is needed by older Chakra-based runtimes where the global is not built in. Modern V8 / JSC / Hermes runtimes already expose it natively, in which case `Initialize()` is a no-op.

## Surface

- `TextEncoder()` constructor — UTF-8 only, per spec
- `encoding` accessor — always `"utf-8"`
- `encode(input)` → `Uint8Array`
- `encodeInto(source, destination)` → `{ read, written }`
  - `read` is in UTF-16 code units, so a 4-byte UTF-8 sequence (code point outside the BMP) reports `2`
  - Multi-byte UTF-8 sequences are never split across the destination boundary

## Build / wiring

- New gated option `JSRUNTIMEHOST_POLYFILL_TEXTENCODER` (default `ON`), matching the pattern used by every other polyfill in this repo.
- New `Polyfills/TextEncoder/` library with the same layout as `Polyfills/TextDecoder/` (`CMakeLists.txt`, `Include/Babylon/Polyfills/TextEncoder.h`, `Source/TextEncoder.cpp`, `README.md`).
- Linked into the unit-test executable (Windows + Android) and initialized in `Tests/UnitTests/Shared/Shared.cpp` next to `TextDecoder::Initialize`.

## Tests

Adds a new `describe("TextEncoder", ...)` block in `Tests/UnitTests/Scripts/tests.ts` covering:
- `encoding === "utf-8"`
- `encode()` on ASCII, undefined / no-arg, multi-byte UTF-8 (e.g. `"é"` → `[0xC3, 0xA9]`), and embedded null bytes
- `encodeInto()` happy path, refusal to split a multi-byte sequence when the destination is too small, and the surrogate-pair `read` semantics for `U+1F600`
- `encodeInto()` `TypeError` when the destination is not a `Uint8Array`

## Motivation

Surfaced during the BabylonNative review of [BabylonJS/BabylonNative#1708](https://github.com/BabylonJS/BabylonNative/pull/1708), where this polyfill originally lived. Per @bghgary's review feedback, `TextEncoder` belongs alongside `TextDecoder` in JsRuntimeHost so it's available to any consumer of this runtime host, not just BN.
