### PR TITLE
Stop mutating instance [[Prototype]] chain in napi_wrap on Chakra

### DIFF
--- a/Core/Node-API/Source/env_chakra.cc
+++ b/Core/Node-API/Source/env_chakra.cc
@@ -31,6 +31,12 @@ namespace Napi
         ThrowIfFailed(JsGetPropertyIdFromName(L"hasOwnProperty", &propertyId));
         ThrowIfFailed(JsGetProperty(prototype, propertyId, &env_ptr->has_own_property_function));
 
+        JsValueRef wrapInfoDescription;
+        ThrowIfFailed(JsPointerToString(L"BabylonNative_External", 22, &wrapInfoDescription));
+        ThrowIfFailed(JsCreateSymbol(wrapInfoDescription, &env_ptr->wrap_info_symbol));
+        ThrowIfFailed(JsAddRef(env_ptr->wrap_info_symbol, nullptr));
+        ThrowIfFailed(JsGetPropertyIdFromSymbol(env_ptr->wrap_info_symbol, &env_ptr->wrap_info_property_id));
+
         return {env_ptr};
     }
 

--- a/Core/Node-API/Source/env_chakra.cc
+++ b/Core/Node-API/Source/env_chakra.cc
@@ -31,11 +31,12 @@ namespace Napi
         ThrowIfFailed(JsGetPropertyIdFromName(L"hasOwnProperty", &propertyId));
         ThrowIfFailed(JsGetProperty(prototype, propertyId, &env_ptr->has_own_property_function));
 
-        JsValueRef wrapInfoDescription;
-        ThrowIfFailed(JsPointerToString(L"BabylonNative_External", 22, &wrapInfoDescription));
-        ThrowIfFailed(JsCreateSymbol(wrapInfoDescription, &env_ptr->wrap_info_symbol));
-        ThrowIfFailed(JsAddRef(env_ptr->wrap_info_symbol, nullptr));
-        ThrowIfFailed(JsGetPropertyIdFromSymbol(env_ptr->wrap_info_symbol, &env_ptr->wrap_info_property_id));
+        JsValueRef wrapSymbolDescription;
+        ThrowIfFailed(JsPointerToString(L"BabylonNative_External", 22, &wrapSymbolDescription));
+        JsValueRef wrapSymbol;
+        ThrowIfFailed(JsCreateSymbol(wrapSymbolDescription, &wrapSymbol));
+        ThrowIfFailed(JsAddRef(wrapSymbol, nullptr));
+        ThrowIfFailed(JsGetPropertyIdFromSymbol(wrapSymbol, &env_ptr->wrap_property_id));
 
         return {env_ptr};
     }

--- a/Core/Node-API/Source/js_native_api_chakra.cc
+++ b/Core/Node-API/Source/js_native_api_chakra.cc
@@ -258,9 +258,9 @@ inline napi_status FindWrapper(napi_env env, JsValueRef obj, JsValueRef* wrapper
   JsValueRef candidate = JS_INVALID_REFERENCE;
   CHECK_JSRT(env, JsGetProperty(descriptor, valuePid, &candidate));
 
-  // Defense in depth: napi_wrap always attaches a JsExternalObject; refuse
-  // anything else so a caller cannot stash a non-external value under the
-  // hidden key and trick napi_unwrap into returning bogus data.
+  // napi_wrap only stores JsExternalObjects under this key, so reject
+  // anything else -- protects against a caller stashing a fake value
+  // under the Symbol to make napi_unwrap return bogus data.
   bool hasExternalData = false;
   CHECK_JSRT(env, JsHasExternalData(candidate, &hasExternalData));
   if (!hasExternalData) {
@@ -1667,8 +1667,9 @@ napi_status napi_wrap(napi_env env,
   // and even if it discovers ours via Object.getOwnPropertySymbols the
   // descriptor flags below prevent overwrite-via-assignment. non-writable
   // blocks `obj[sym] = junk`; non-enumerable for hygiene; configurable so
-  // napi_remove_wrap can delete it. (FindWrapper still gates on
-  // JsHasExternalData as defense-in-depth against re-define attempts.)
+  // napi_remove_wrap can delete it. (FindWrapper still checks
+  // JsHasExternalData to reject anything stashed under the key that
+  // isn't a real wrapper.)
   // This keeps the value's prototype chain intact, so
   // Object.getPrototypeOf(value) still returns whatever the constructor
   // installed.

--- a/Core/Node-API/Source/js_native_api_chakra.cc
+++ b/Core/Node-API/Source/js_native_api_chakra.cc
@@ -229,9 +229,6 @@ JsErrorCode JsNameValueFromPropertyDescriptor(const napi_property_descriptor* p,
 }
 
 inline napi_status FindWrapper(napi_env env, JsValueRef obj, JsValueRef* wrapper) {
-  // Look up the external attached by napi_wrap as a hidden own property
-  // keyed by env->wrap_property_id. Returns JS_INVALID_REFERENCE in
-  // *wrapper when the value was never wrapped (or isn't an object).
   *wrapper = JS_INVALID_REFERENCE;
 
   JsValueType valueType;
@@ -240,10 +237,9 @@ inline napi_status FindWrapper(napi_env env, JsValueRef obj, JsValueRef* wrapper
     return napi_ok;
   }
 
-  // Use GetOwnPropertyDescriptor (not JsHasProperty) so a wrap-key
-  // property defined on Object.prototype (e.g. if some Object.prototype
-  // value were itself wrapped) cannot spoof an unwrap of an otherwise-
-  // unwrapped value via prototype-chain lookup.
+  // Use GetOwnPropertyDescriptor rather than JsGetProperty so a wrap-key
+  // property installed on Object.prototype cannot spoof an unwrap via the
+  // prototype chain.
   JsValueRef descriptor = JS_INVALID_REFERENCE;
   CHECK_JSRT(env, JsGetOwnPropertyDescriptor(obj, env->wrap_property_id, &descriptor));
 
@@ -259,9 +255,9 @@ inline napi_status FindWrapper(napi_env env, JsValueRef obj, JsValueRef* wrapper
   JsValueRef candidate = JS_INVALID_REFERENCE;
   CHECK_JSRT(env, JsGetProperty(descriptor, valuePid, &candidate));
 
-  // napi_wrap only stores JsExternalObjects under this key, so reject
-  // anything else -- protects against a caller stashing a fake value
-  // under the Symbol to make napi_unwrap return bogus data.
+  // Reject anything other than a JsExternalObject so a caller that
+  // stashed a fake value under the wrap key cannot make napi_unwrap
+  // hand back bogus data.
   bool hasExternalData = false;
   CHECK_JSRT(env, JsHasExternalData(candidate, &hasExternalData));
   if (!hasExternalData) {
@@ -445,13 +441,11 @@ struct DataViewInfo {
   }
 };
 
-// Defines a property on `object` keyed by `property_id`. Each of `value`,
-// `getter`, and `setter` is included in the descriptor only when non-
-// JS_INVALID_REFERENCE; `writable` is included only when set (method
-// properties intentionally omit it). `enumerable` and `configurable` are
-// always set. Writes whether Chakra accepted the descriptor into `*defined`
-// (false means the property already exists with conflicting flags); the
-// caller decides whether to treat that as an error.
+// `writable` is std::optional because the method-property branch in
+// napi_define_properties intentionally omits it.
+//
+// `*defined` is false if the property already exists with conflicting
+// flags; the caller decides whether to treat that as an error.
 napi_status DefineProperty(napi_env env,
                            JsValueRef object,
                            JsPropertyIdRef property_id,
@@ -1680,17 +1674,6 @@ napi_status napi_wrap(napi_env env,
   CHECK_JSRT(env, JsCreateExternalObject(
     externalData, ExternalData::Finalize, &external));
 
-  // Attach the external as a hidden own property keyed by the env's
-  // wrap-key Symbol. User code cannot construct an equal Symbol from JS,
-  // and even if it discovers ours via Object.getOwnPropertySymbols the
-  // descriptor flags below prevent overwrite-via-assignment. non-writable
-  // blocks `obj[sym] = junk`; non-enumerable for hygiene; configurable so
-  // napi_remove_wrap can delete it. (FindWrapper still checks
-  // JsHasExternalData to reject anything stashed under the key that
-  // isn't a real wrapper.)
-  // This keeps the value's prototype chain intact, so
-  // Object.getPrototypeOf(value) still returns whatever the constructor
-  // installed.
   bool defined = false;
   CHECK_NAPI(DefineProperty(env, value, env->wrap_property_id,
     /*value*/ external,

--- a/Core/Node-API/Source/js_native_api_chakra.cc
+++ b/Core/Node-API/Source/js_native_api_chakra.cc
@@ -3,6 +3,7 @@
 #include <array>
 #include <cassert>
 #include <cmath>
+#include <optional>
 #include <vector>
 #include <string>
 #include <stdexcept>
@@ -444,45 +445,53 @@ struct DataViewInfo {
   }
 };
 
-// Defines a data property on `object` keyed by `property_id` with the given
-// value and attribute flags. Writes whether Chakra accepted the descriptor
-// into `*defined` (false means the property already exists with conflicting
-// flags); the caller decides whether to treat that as an error.
-napi_status DefineDataProperty(napi_env env,
-                               JsValueRef object,
-                               JsPropertyIdRef property_id,
-                               JsValueRef value,
-                               bool writable,
-                               bool enumerable,
-                               bool configurable,
-                               bool* defined) {
+// Defines a property on `object` keyed by `property_id`. Each of `value`,
+// `getter`, and `setter` is included in the descriptor only when non-
+// JS_INVALID_REFERENCE; `writable` is included only when set (method
+// properties intentionally omit it). `enumerable` and `configurable` are
+// always set. Writes whether Chakra accepted the descriptor into `*defined`
+// (false means the property already exists with conflicting flags); the
+// caller decides whether to treat that as an error.
+napi_status DefineProperty(napi_env env,
+                           JsValueRef object,
+                           JsPropertyIdRef property_id,
+                           JsValueRef value,
+                           JsValueRef getter,
+                           JsValueRef setter,
+                           std::optional<bool> writable,
+                           bool enumerable,
+                           bool configurable,
+                           bool* defined) {
   JsValueRef descriptor;
   CHECK_JSRT(env, JsCreateObject(&descriptor));
 
-  JsValueRef writableValue;
-  CHECK_JSRT(env, JsBoolToBoolean(writable, &writableValue));
+  auto setField = [&](const char* name, size_t len, JsValueRef v) -> napi_status {
+    JsPropertyIdRef pid;
+    CHECK_JSRT(env, JsCreatePropertyId(name, len, &pid));
+    CHECK_JSRT(env, JsSetProperty(descriptor, pid, v, true));
+    return napi_ok;
+  };
 
-  JsValueRef enumerableValue;
-  CHECK_JSRT(env, JsBoolToBoolean(enumerable, &enumerableValue));
+  auto setBoolField = [&](const char* name, size_t len, bool v) -> napi_status {
+    JsValueRef vr;
+    CHECK_JSRT(env, JsBoolToBoolean(v, &vr));
+    return setField(name, len, vr);
+  };
 
-  JsValueRef configurableValue;
-  CHECK_JSRT(env, JsBoolToBoolean(configurable, &configurableValue));
-
-  JsPropertyIdRef valuePid;
-  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("value"), &valuePid));
-  CHECK_JSRT(env, JsSetProperty(descriptor, valuePid, value, true));
-
-  JsPropertyIdRef writablePid;
-  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("writable"), &writablePid));
-  CHECK_JSRT(env, JsSetProperty(descriptor, writablePid, writableValue, true));
-
-  JsPropertyIdRef enumerablePid;
-  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("enumerable"), &enumerablePid));
-  CHECK_JSRT(env, JsSetProperty(descriptor, enumerablePid, enumerableValue, true));
-
-  JsPropertyIdRef configurablePid;
-  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("configurable"), &configurablePid));
-  CHECK_JSRT(env, JsSetProperty(descriptor, configurablePid, configurableValue, true));
+  CHECK_NAPI(setBoolField(STR_AND_LENGTH("enumerable"), enumerable));
+  CHECK_NAPI(setBoolField(STR_AND_LENGTH("configurable"), configurable));
+  if (writable.has_value()) {
+    CHECK_NAPI(setBoolField(STR_AND_LENGTH("writable"), *writable));
+  }
+  if (value != JS_INVALID_REFERENCE) {
+    CHECK_NAPI(setField(STR_AND_LENGTH("value"), value));
+  }
+  if (getter != JS_INVALID_REFERENCE) {
+    CHECK_NAPI(setField(STR_AND_LENGTH("get"), getter));
+  }
+  if (setter != JS_INVALID_REFERENCE) {
+    CHECK_NAPI(setField(STR_AND_LENGTH("set"), setter));
+  }
 
   CHECK_JSRT(env, JsDefineProperty(object, property_id, descriptor, defined));
   return napi_ok;
@@ -846,44 +855,18 @@ napi_status napi_define_properties(napi_env env,
     CHECK_ARG(env, properties);
   }
 
-  JsPropertyIdRef configurableProperty;
-  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("configurable"),
-                                &configurableProperty));
-
-  JsPropertyIdRef enumerableProperty;
-  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("enumerable"),
-                                &enumerableProperty));
-
   for (size_t i = 0; i < property_count; i++) {
     const napi_property_descriptor* p = properties + i;
 
     JsPropertyIdRef nameProperty;
     CHECK_JSRT(env, JsPropertyIdFromPropertyDescriptor(p, &nameProperty));
 
-    if (p->getter == nullptr && p->setter == nullptr && p->method == nullptr) {
-      RETURN_STATUS_IF_FALSE(env, p->value != nullptr, napi_invalid_arg);
-      bool defined;
-      CHECK_NAPI(DefineDataProperty(env,
-        reinterpret_cast<JsValueRef>(object),
-        nameProperty,
-        reinterpret_cast<JsValueRef>(p->value),
-        (p->attributes & napi_writable) != 0,
-        (p->attributes & napi_enumerable) != 0,
-        (p->attributes & napi_configurable) != 0,
-        &defined));
-      continue;
-    }
-
-    JsValueRef descriptor;
-    CHECK_JSRT(env, JsCreateObject(&descriptor));
-
-    JsValueRef configurable;
-    CHECK_JSRT(env, JsBoolToBoolean((p->attributes & napi_configurable), &configurable));
-    CHECK_JSRT(env, JsSetProperty(descriptor, configurableProperty, configurable, true));
-
-    JsValueRef enumerable;
-    CHECK_JSRT(env, JsBoolToBoolean((p->attributes & napi_enumerable), &enumerable));
-    CHECK_JSRT(env, JsSetProperty(descriptor, enumerableProperty, enumerable, true));
+    JsValueRef value = JS_INVALID_REFERENCE;
+    JsValueRef getter = JS_INVALID_REFERENCE;
+    JsValueRef setter = JS_INVALID_REFERENCE;
+    std::optional<bool> writable;
+    bool enumerable = (p->attributes & napi_enumerable) != 0;
+    bool configurable = (p->attributes & napi_configurable) != 0;
 
     if (p->getter != nullptr || p->setter != nullptr) {
       napi_value property_name;
@@ -891,41 +874,31 @@ napi_status napi_define_properties(napi_env env,
         JsNameValueFromPropertyDescriptor(p, &property_name));
 
       if (p->getter != nullptr) {
-        JsPropertyIdRef getProperty;
-        CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("get"), &getProperty));
-        JsValueRef getter;
         CHECK_NAPI(CreatePropertyFunction(env, property_name,
           p->getter, p->data, reinterpret_cast<napi_value*>(&getter)));
-        CHECK_JSRT(env, JsSetProperty(descriptor, getProperty, getter, true));
       }
 
       if (p->setter != nullptr) {
-        JsPropertyIdRef setProperty;
-        CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("set"), &setProperty));
-        JsValueRef setter;
         CHECK_NAPI(CreatePropertyFunction(env, property_name,
           p->setter, p->data, reinterpret_cast<napi_value*>(&setter)));
-        CHECK_JSRT(env, JsSetProperty(descriptor, setProperty, setter, true));
       }
-    } else {
+    } else if (p->method != nullptr) {
       napi_value property_name;
       CHECK_JSRT(env,
         JsNameValueFromPropertyDescriptor(p, &property_name));
 
-      JsPropertyIdRef valueProperty;
-      CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("value"), &valueProperty));
-      JsValueRef method;
       CHECK_NAPI(CreatePropertyFunction(env, property_name,
-        p->method, p->data, reinterpret_cast<napi_value*>(&method)));
-      CHECK_JSRT(env, JsSetProperty(descriptor, valueProperty, method, true));
+        p->method, p->data, reinterpret_cast<napi_value*>(&value)));
+    } else {
+      RETURN_STATUS_IF_FALSE(env, p->value != nullptr, napi_invalid_arg);
+      value = reinterpret_cast<JsValueRef>(p->value);
+      writable = (p->attributes & napi_writable) != 0;
     }
 
-    bool result;
-    CHECK_JSRT(env, JsDefineProperty(
-      reinterpret_cast<JsValueRef>(object),
-      nameProperty,
-      descriptor,
-      &result));
+    bool defined;
+    CHECK_NAPI(DefineProperty(env, reinterpret_cast<JsValueRef>(object),
+      nameProperty, value, getter, setter, writable, enumerable,
+      configurable, &defined));
   }
 
   return napi_ok;
@@ -1719,8 +1692,14 @@ napi_status napi_wrap(napi_env env,
   // Object.getPrototypeOf(value) still returns whatever the constructor
   // installed.
   bool defined = false;
-  CHECK_NAPI(DefineDataProperty(env, value, env->wrap_property_id, external,
-    /*writable*/ false, /*enumerable*/ false, /*configurable*/ true, &defined));
+  CHECK_NAPI(DefineProperty(env, value, env->wrap_property_id,
+    /*value*/ external,
+    /*getter*/ JS_INVALID_REFERENCE,
+    /*setter*/ JS_INVALID_REFERENCE,
+    /*writable*/ false,
+    /*enumerable*/ false,
+    /*configurable*/ true,
+    &defined));
   RETURN_STATUS_IF_FALSE(env, defined, napi_invalid_arg);
 
   if (result != nullptr) {

--- a/Core/Node-API/Source/js_native_api_chakra.cc
+++ b/Core/Node-API/Source/js_native_api_chakra.cc
@@ -441,11 +441,6 @@ struct DataViewInfo {
   }
 };
 
-// `writable` is std::optional because the method-property branch in
-// napi_define_properties intentionally omits it.
-//
-// `*defined` is false if the property already exists with conflicting
-// flags; the caller decides whether to treat that as an error.
 napi_status DefineProperty(napi_env env,
                            JsValueRef object,
                            JsPropertyIdRef property_id,

--- a/Core/Node-API/Source/js_native_api_chakra.cc
+++ b/Core/Node-API/Source/js_native_api_chakra.cc
@@ -444,6 +444,50 @@ struct DataViewInfo {
   }
 };
 
+// Defines a data property on `object` keyed by `property_id` with the given
+// value and attribute flags. Writes whether Chakra accepted the descriptor
+// into `*defined` (false means the property already exists with conflicting
+// flags); the caller decides whether to treat that as an error.
+napi_status DefineDataProperty(napi_env env,
+                               JsValueRef object,
+                               JsPropertyIdRef property_id,
+                               JsValueRef value,
+                               bool writable,
+                               bool enumerable,
+                               bool configurable,
+                               bool* defined) {
+  JsValueRef descriptor;
+  CHECK_JSRT(env, JsCreateObject(&descriptor));
+
+  JsValueRef writableValue;
+  CHECK_JSRT(env, JsBoolToBoolean(writable, &writableValue));
+
+  JsValueRef enumerableValue;
+  CHECK_JSRT(env, JsBoolToBoolean(enumerable, &enumerableValue));
+
+  JsValueRef configurableValue;
+  CHECK_JSRT(env, JsBoolToBoolean(configurable, &configurableValue));
+
+  JsPropertyIdRef valuePid;
+  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("value"), &valuePid));
+  CHECK_JSRT(env, JsSetProperty(descriptor, valuePid, value, true));
+
+  JsPropertyIdRef writablePid;
+  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("writable"), &writablePid));
+  CHECK_JSRT(env, JsSetProperty(descriptor, writablePid, writableValue, true));
+
+  JsPropertyIdRef enumerablePid;
+  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("enumerable"), &enumerablePid));
+  CHECK_JSRT(env, JsSetProperty(descriptor, enumerablePid, enumerableValue, true));
+
+  JsPropertyIdRef configurablePid;
+  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("configurable"), &configurablePid));
+  CHECK_JSRT(env, JsSetProperty(descriptor, configurablePid, configurableValue, true));
+
+  CHECK_JSRT(env, JsDefineProperty(object, property_id, descriptor, defined));
+  return napi_ok;
+}
+
 } // end anonymous namespace
 
 // Warning: Keep in-sync with napi_status enum
@@ -813,6 +857,23 @@ napi_status napi_define_properties(napi_env env,
   for (size_t i = 0; i < property_count; i++) {
     const napi_property_descriptor* p = properties + i;
 
+    JsPropertyIdRef nameProperty;
+    CHECK_JSRT(env, JsPropertyIdFromPropertyDescriptor(p, &nameProperty));
+
+    if (p->getter == nullptr && p->setter == nullptr && p->method == nullptr) {
+      RETURN_STATUS_IF_FALSE(env, p->value != nullptr, napi_invalid_arg);
+      bool defined;
+      CHECK_NAPI(DefineDataProperty(env,
+        reinterpret_cast<JsValueRef>(object),
+        nameProperty,
+        reinterpret_cast<JsValueRef>(p->value),
+        (p->attributes & napi_writable) != 0,
+        (p->attributes & napi_enumerable) != 0,
+        (p->attributes & napi_configurable) != 0,
+        &defined));
+      continue;
+    }
+
     JsValueRef descriptor;
     CHECK_JSRT(env, JsCreateObject(&descriptor));
 
@@ -846,7 +907,7 @@ napi_status napi_define_properties(napi_env env,
           p->setter, p->data, reinterpret_cast<napi_value*>(&setter)));
         CHECK_JSRT(env, JsSetProperty(descriptor, setProperty, setter, true));
       }
-    } else if (p->method != nullptr) {
+    } else {
       napi_value property_name;
       CHECK_JSRT(env,
         JsNameValueFromPropertyDescriptor(p, &property_name));
@@ -857,29 +918,13 @@ napi_status napi_define_properties(napi_env env,
       CHECK_NAPI(CreatePropertyFunction(env, property_name,
         p->method, p->data, reinterpret_cast<napi_value*>(&method)));
       CHECK_JSRT(env, JsSetProperty(descriptor, valueProperty, method, true));
-    } else {
-      RETURN_STATUS_IF_FALSE(env, p->value != nullptr, napi_invalid_arg);
-
-      JsPropertyIdRef writableProperty;
-      CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("writable"),
-                                    &writableProperty));
-      JsValueRef writable;
-      CHECK_JSRT(env, JsBoolToBoolean((p->attributes & napi_writable), &writable));
-      CHECK_JSRT(env, JsSetProperty(descriptor, writableProperty, writable, true));
-
-      JsPropertyIdRef valueProperty;
-      CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("value"), &valueProperty));
-      CHECK_JSRT(env, JsSetProperty(descriptor, valueProperty,
-        reinterpret_cast<JsValueRef>(p->value), true));
     }
 
-    JsPropertyIdRef nameProperty;
-    CHECK_JSRT(env, JsPropertyIdFromPropertyDescriptor(p, &nameProperty));
     bool result;
     CHECK_JSRT(env, JsDefineProperty(
       reinterpret_cast<JsValueRef>(object),
-      reinterpret_cast<JsPropertyIdRef>(nameProperty),
-      reinterpret_cast<JsValueRef>(descriptor),
+      nameProperty,
+      descriptor,
       &result));
   }
 
@@ -1673,33 +1718,9 @@ napi_status napi_wrap(napi_env env,
   // This keeps the value's prototype chain intact, so
   // Object.getPrototypeOf(value) still returns whatever the constructor
   // installed.
-  JsValueRef descriptor;
-  CHECK_JSRT(env, JsCreateObject(&descriptor));
-
-  JsValueRef falseValue;
-  CHECK_JSRT(env, JsBoolToBoolean(false, &falseValue));
-
-  JsValueRef trueValue;
-  CHECK_JSRT(env, JsBoolToBoolean(true, &trueValue));
-
-  JsPropertyIdRef valuePid;
-  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("value"), &valuePid));
-  CHECK_JSRT(env, JsSetProperty(descriptor, valuePid, external, true));
-
-  JsPropertyIdRef writablePid;
-  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("writable"), &writablePid));
-  CHECK_JSRT(env, JsSetProperty(descriptor, writablePid, falseValue, true));
-
-  JsPropertyIdRef enumerablePid;
-  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("enumerable"), &enumerablePid));
-  CHECK_JSRT(env, JsSetProperty(descriptor, enumerablePid, falseValue, true));
-
-  JsPropertyIdRef configurablePid;
-  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("configurable"), &configurablePid));
-  CHECK_JSRT(env, JsSetProperty(descriptor, configurablePid, trueValue, true));
-
   bool defined = false;
-  CHECK_JSRT(env, JsDefineProperty(value, env->wrap_property_id, descriptor, &defined));
+  CHECK_NAPI(DefineDataProperty(env, value, env->wrap_property_id, external,
+    /*writable*/ false, /*enumerable*/ false, /*configurable*/ true, &defined));
   RETURN_STATUS_IF_FALSE(env, defined, napi_invalid_arg);
 
   if (result != nullptr) {

--- a/Core/Node-API/Source/js_native_api_chakra.cc
+++ b/Core/Node-API/Source/js_native_api_chakra.cc
@@ -229,7 +229,7 @@ JsErrorCode JsNameValueFromPropertyDescriptor(const napi_property_descriptor* p,
 
 inline napi_status FindWrapper(napi_env env, JsValueRef obj, JsValueRef* wrapper) {
   // Look up the external attached by napi_wrap as a hidden own property
-  // keyed by env->wrap_info_symbol. Returns JS_INVALID_REFERENCE in
+  // keyed by env->wrap_property_id. Returns JS_INVALID_REFERENCE in
   // *wrapper when the value was never wrapped (or isn't an object).
   *wrapper = JS_INVALID_REFERENCE;
 
@@ -239,12 +239,12 @@ inline napi_status FindWrapper(napi_env env, JsValueRef obj, JsValueRef* wrapper
     return napi_ok;
   }
 
-  // Use GetOwnPropertyDescriptor (not JsHasProperty) so a wrap-info symbol
+  // Use GetOwnPropertyDescriptor (not JsHasProperty) so a wrap-key
   // property defined on Object.prototype (e.g. if some Object.prototype
   // value were itself wrapped) cannot spoof an unwrap of an otherwise-
   // unwrapped value via prototype-chain lookup.
   JsValueRef descriptor = JS_INVALID_REFERENCE;
-  CHECK_JSRT(env, JsGetOwnPropertyDescriptor(obj, env->wrap_info_property_id, &descriptor));
+  CHECK_JSRT(env, JsGetOwnPropertyDescriptor(obj, env->wrap_property_id, &descriptor));
 
   JsValueType descriptorType;
   CHECK_JSRT(env, JsGetValueType(descriptor, &descriptorType));
@@ -1663,7 +1663,7 @@ napi_status napi_wrap(napi_env env,
     externalData, ExternalData::Finalize, &external));
 
   // Attach the external as a hidden own property keyed by the env's
-  // wrap-info Symbol. User code cannot construct an equal Symbol from JS,
+  // wrap-key Symbol. User code cannot construct an equal Symbol from JS,
   // and even if it discovers ours via Object.getOwnPropertySymbols the
   // descriptor flags below prevent overwrite-via-assignment. non-writable
   // blocks `obj[sym] = junk`; non-enumerable for hygiene; configurable so
@@ -1698,7 +1698,7 @@ napi_status napi_wrap(napi_env env,
   CHECK_JSRT(env, JsSetProperty(descriptor, configurablePid, trueValue, true));
 
   bool defined = false;
-  CHECK_JSRT(env, JsDefineProperty(value, env->wrap_info_property_id, descriptor, &defined));
+  CHECK_JSRT(env, JsDefineProperty(value, env->wrap_property_id, descriptor, &defined));
   RETURN_STATUS_IF_FALSE(env, defined, napi_invalid_arg);
 
   if (result != nullptr) {
@@ -1738,7 +1738,7 @@ napi_status napi_remove_wrap(napi_env env, napi_value js_object, void** result) 
   // detaching the external data so a subsequent napi_unwrap still returns
   // the original data rather than a stale property with cleared external.
   JsValueRef deleteResult = JS_INVALID_REFERENCE;
-  CHECK_JSRT(env, JsDeleteProperty(value, env->wrap_info_property_id, false /* isStrictMode */, &deleteResult));
+  CHECK_JSRT(env, JsDeleteProperty(value, env->wrap_property_id, false /* isStrictMode */, &deleteResult));
 
   bool wasDeleted = false;
   CHECK_JSRT(env, JsBooleanToBool(deleteResult, &wasDeleted));

--- a/Core/Node-API/Source/js_native_api_chakra.cc
+++ b/Core/Node-API/Source/js_native_api_chakra.cc
@@ -241,24 +241,45 @@ inline napi_status FindWrapper(napi_env env, JsValueRef obj, JsValueRef* wrapper
   // Look up the external attached by napi_wrap as a hidden own property.
   // Returns JS_INVALID_REFERENCE in *wrapper when the value was never
   // wrapped (or isn't an object).
+  *wrapper = JS_INVALID_REFERENCE;
+
   JsValueType valueType;
   CHECK_JSRT(env, JsGetValueType(obj, &valueType));
   if (valueType != JsObject && valueType != JsFunction) {
-    *wrapper = JS_INVALID_REFERENCE;
     return napi_ok;
   }
 
   JsPropertyIdRef wrapKey;
   CHECK_NAPI(GetWrapPropertyId(env, &wrapKey));
 
-  bool hasWrap = false;
-  CHECK_JSRT(env, JsHasProperty(obj, wrapKey, &hasWrap));
-  if (!hasWrap) {
-    *wrapper = JS_INVALID_REFERENCE;
+  // Use GetOwnPropertyDescriptor (not JsHasProperty) so a stray
+  // "\x01napi_external" defined on Object.prototype (or any other object
+  // up the chain) cannot spoof an unwrap of an otherwise-unwrapped value.
+  JsValueRef descriptor = JS_INVALID_REFERENCE;
+  CHECK_JSRT(env, JsGetOwnPropertyDescriptor(obj, wrapKey, &descriptor));
+
+  JsValueType descriptorType;
+  CHECK_JSRT(env, JsGetValueType(descriptor, &descriptorType));
+  if (descriptorType == JsUndefined) {
     return napi_ok;
   }
 
-  CHECK_JSRT(env, JsGetProperty(obj, wrapKey, wrapper));
+  JsPropertyIdRef valuePid;
+  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("value"), &valuePid));
+
+  JsValueRef candidate = JS_INVALID_REFERENCE;
+  CHECK_JSRT(env, JsGetProperty(descriptor, valuePid, &candidate));
+
+  // Defense in depth: napi_wrap always attaches a JsExternalObject; refuse
+  // anything else so a caller cannot stash a non-external value under the
+  // hidden key and trick napi_unwrap into returning bogus data.
+  bool hasExternalData = false;
+  CHECK_JSRT(env, JsHasExternalData(candidate, &hasExternalData));
+  if (!hasExternalData) {
+    return napi_ok;
+  }
+
+  *wrapper = candidate;
   return napi_ok;
 }
 
@@ -1723,13 +1744,19 @@ napi_status napi_remove_wrap(napi_env env, napi_value js_object, void** result) 
   CHECK_NAPI(Unwrap(env, value, &externalData, &wrapper));
   RETURN_STATUS_IF_FALSE(env, wrapper != JS_INVALID_REFERENCE, napi_invalid_arg);
 
-  // Remove the hidden wrap property and detach the external data so the
-  // external object can be collected and Finalize won't run twice.
+  // Remove the hidden wrap property first. If deletion fails (e.g. user
+  // code redefined it as non-configurable after napi_wrap), bail before
+  // detaching the external data so a subsequent napi_unwrap still returns
+  // the original data rather than a stale property with cleared external.
   JsPropertyIdRef wrapKey;
   CHECK_NAPI(GetWrapPropertyId(env, &wrapKey));
 
   JsValueRef deleteResult = JS_INVALID_REFERENCE;
   CHECK_JSRT(env, JsDeleteProperty(value, wrapKey, false /* isStrictMode */, &deleteResult));
+
+  bool wasDeleted = false;
+  CHECK_JSRT(env, JsBooleanToBool(deleteResult, &wasDeleted));
+  RETURN_STATUS_IF_FALSE(env, wasDeleted, napi_generic_failure);
 
   CHECK_JSRT(env, JsSetExternalData(wrapper, nullptr));
 

--- a/Core/Node-API/Source/js_native_api_chakra.cc
+++ b/Core/Node-API/Source/js_native_api_chakra.cc
@@ -227,46 +227,44 @@ JsErrorCode JsNameValueFromPropertyDescriptor(const napi_property_descriptor* p,
   }
 }
 
-inline napi_status FindWrapper(napi_env env, JsValueRef obj, JsValueRef* wrapper, JsValueRef* parent = nullptr) {
-  // Search the object's prototype chain for the wrapper with external data.
-  // Usually the wrapper would be the first in the chain, but it is OK for
-  // other objects to be inserted in the prototype chain.
-  JsValueRef candidate = obj;
-  JsValueRef current = JS_INVALID_REFERENCE;
-  bool hasExternalData = false;
-
-  JsValueRef nullValue = JS_INVALID_REFERENCE;
-  CHECK_JSRT(env, JsGetNullValue(&nullValue));
-
-  do {
-    current = candidate;
-
-    CHECK_JSRT(env, JsGetPrototype(current, &candidate));
-    if (candidate == JS_INVALID_REFERENCE || candidate == nullValue) {
-      if (parent != nullptr) {
-        *parent = JS_INVALID_REFERENCE;
-      }
-
-      *wrapper = JS_INVALID_REFERENCE;
-      return napi_ok;
-    }
-
-    CHECK_JSRT(env, JsHasExternalData(candidate, &hasExternalData));
-  } while (!hasExternalData);
-
-  if (parent != nullptr) {
-    *parent = current;
-  }
-
-  *wrapper = candidate;
-
+inline napi_status GetWrapPropertyId(napi_env env, JsPropertyIdRef* result) {
+  // Hidden own-property key used to attach napi_wrap externals without
+  // mutating the wrapped value's prototype chain. The SOH (\x01) prefix
+  // keeps the name out of user-typed identifier space; the property is
+  // also defined as non-enumerable / non-writable in napi_wrap so it
+  // cannot be observed via for..in or overwritten by assignment.
+  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("\x01napi_external"), result));
   return napi_ok;
 }
 
-inline napi_status Unwrap(napi_env env, JsValueRef obj, ExternalData** externalData, JsValueRef* wrapper = nullptr, JsValueRef* parent = nullptr) {
+inline napi_status FindWrapper(napi_env env, JsValueRef obj, JsValueRef* wrapper) {
+  // Look up the external attached by napi_wrap as a hidden own property.
+  // Returns JS_INVALID_REFERENCE in *wrapper when the value was never
+  // wrapped (or isn't an object).
+  JsValueType valueType;
+  CHECK_JSRT(env, JsGetValueType(obj, &valueType));
+  if (valueType != JsObject && valueType != JsFunction) {
+    *wrapper = JS_INVALID_REFERENCE;
+    return napi_ok;
+  }
+
+  JsPropertyIdRef wrapKey;
+  CHECK_NAPI(GetWrapPropertyId(env, &wrapKey));
+
+  bool hasWrap = false;
+  CHECK_JSRT(env, JsHasProperty(obj, wrapKey, &hasWrap));
+  if (!hasWrap) {
+    *wrapper = JS_INVALID_REFERENCE;
+    return napi_ok;
+  }
+
+  CHECK_JSRT(env, JsGetProperty(obj, wrapKey, wrapper));
+  return napi_ok;
+}
+
+inline napi_status Unwrap(napi_env env, JsValueRef obj, ExternalData** externalData, JsValueRef* wrapper = nullptr) {
   JsValueRef candidate = JS_INVALID_REFERENCE;
-  JsValueRef candidateParent = JS_INVALID_REFERENCE;
-  CHECK_NAPI(FindWrapper(env, obj, &candidate, &candidateParent));
+  CHECK_NAPI(FindWrapper(env, obj, &candidate));
   RETURN_STATUS_IF_FALSE(env, candidate != JS_INVALID_REFERENCE, napi_invalid_arg);
 
   CHECK_JSRT(env, JsGetExternalData(candidate,
@@ -274,10 +272,6 @@ inline napi_status Unwrap(napi_env env, JsValueRef obj, ExternalData** externalD
 
   if (wrapper != nullptr) {
     *wrapper = candidate;
-  }
-
-  if (parent != nullptr) {
-    *parent = candidateParent;
   }
 
   return napi_ok;
@@ -1659,11 +1653,43 @@ napi_status napi_wrap(napi_env env,
   CHECK_JSRT(env, JsCreateExternalObject(
     externalData, ExternalData::Finalize, &external));
 
-  // Insert the external object into the value's prototype chain.
-  JsValueRef valuePrototype = JS_INVALID_REFERENCE;
-  CHECK_JSRT(env, JsGetPrototype(value, &valuePrototype));
-  CHECK_JSRT(env, JsSetPrototype(external, valuePrototype));
-  CHECK_JSRT(env, JsSetPrototype(value, external));
+  // Attach the external as a hidden own property (non-enumerable so it
+  // does not appear in for..in / Object.keys / JSON.stringify, non-writable
+  // so a stray assignment cannot replace it). Configurable so napi_remove_wrap
+  // can delete it. This keeps the value's prototype chain intact, so
+  // Object.getPrototypeOf(value) still returns whatever the constructor
+  // installed.
+  JsPropertyIdRef wrapKey;
+  CHECK_NAPI(GetWrapPropertyId(env, &wrapKey));
+
+  JsValueRef descriptor;
+  CHECK_JSRT(env, JsCreateObject(&descriptor));
+
+  JsValueRef falseValue;
+  CHECK_JSRT(env, JsBoolToBoolean(false, &falseValue));
+
+  JsValueRef trueValue;
+  CHECK_JSRT(env, JsBoolToBoolean(true, &trueValue));
+
+  JsPropertyIdRef valuePid;
+  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("value"), &valuePid));
+  CHECK_JSRT(env, JsSetProperty(descriptor, valuePid, external, true));
+
+  JsPropertyIdRef writablePid;
+  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("writable"), &writablePid));
+  CHECK_JSRT(env, JsSetProperty(descriptor, writablePid, falseValue, true));
+
+  JsPropertyIdRef enumerablePid;
+  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("enumerable"), &enumerablePid));
+  CHECK_JSRT(env, JsSetProperty(descriptor, enumerablePid, falseValue, true));
+
+  JsPropertyIdRef configurablePid;
+  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("configurable"), &configurablePid));
+  CHECK_JSRT(env, JsSetProperty(descriptor, configurablePid, trueValue, true));
+
+  bool defined = false;
+  CHECK_JSRT(env, JsDefineProperty(value, wrapKey, descriptor, &defined));
+  RETURN_STATUS_IF_FALSE(env, defined, napi_invalid_arg);
 
   if (result != nullptr) {
     CHECK_NAPI(napi_create_reference(env, js_object, 0, result));
@@ -1693,18 +1719,18 @@ napi_status napi_remove_wrap(napi_env env, napi_value js_object, void** result) 
   JsValueRef value = reinterpret_cast<JsValueRef>(js_object);
 
   ExternalData* externalData = nullptr;
-  JsValueRef parent = JS_INVALID_REFERENCE;
   JsValueRef wrapper = JS_INVALID_REFERENCE;
-  CHECK_NAPI(Unwrap(env, value, &externalData, &wrapper, &parent));
-  RETURN_STATUS_IF_FALSE(env, parent != JS_INVALID_REFERENCE, napi_invalid_arg);
+  CHECK_NAPI(Unwrap(env, value, &externalData, &wrapper));
   RETURN_STATUS_IF_FALSE(env, wrapper != JS_INVALID_REFERENCE, napi_invalid_arg);
 
-  // Remove the external from the prototype chain
-  JsValueRef wrapperProto = JS_INVALID_REFERENCE;
-  CHECK_JSRT(env, JsGetPrototype(wrapper, &wrapperProto));
-  CHECK_JSRT(env, JsSetPrototype(parent, wrapperProto));
+  // Remove the hidden wrap property and detach the external data so the
+  // external object can be collected and Finalize won't run twice.
+  JsPropertyIdRef wrapKey;
+  CHECK_NAPI(GetWrapPropertyId(env, &wrapKey));
 
-  // Clear the external data from the object
+  JsValueRef deleteResult = JS_INVALID_REFERENCE;
+  CHECK_JSRT(env, JsDeleteProperty(value, wrapKey, false /* isStrictMode */, &deleteResult));
+
   CHECK_JSRT(env, JsSetExternalData(wrapper, nullptr));
 
   if (externalData != nullptr) {

--- a/Core/Node-API/Source/js_native_api_chakra.cc
+++ b/Core/Node-API/Source/js_native_api_chakra.cc
@@ -227,20 +227,10 @@ JsErrorCode JsNameValueFromPropertyDescriptor(const napi_property_descriptor* p,
   }
 }
 
-inline napi_status GetWrapPropertyId(napi_env env, JsPropertyIdRef* result) {
-  // Hidden own-property key used to attach napi_wrap externals without
-  // mutating the wrapped value's prototype chain. The SOH (\x01) prefix
-  // keeps the name out of user-typed identifier space; the property is
-  // also defined as non-enumerable / non-writable in napi_wrap so it
-  // cannot be observed via for..in or overwritten by assignment.
-  CHECK_JSRT(env, JsCreatePropertyId(STR_AND_LENGTH("\x01napi_external"), result));
-  return napi_ok;
-}
-
 inline napi_status FindWrapper(napi_env env, JsValueRef obj, JsValueRef* wrapper) {
-  // Look up the external attached by napi_wrap as a hidden own property.
-  // Returns JS_INVALID_REFERENCE in *wrapper when the value was never
-  // wrapped (or isn't an object).
+  // Look up the external attached by napi_wrap as a hidden own property
+  // keyed by env->wrap_info_symbol. Returns JS_INVALID_REFERENCE in
+  // *wrapper when the value was never wrapped (or isn't an object).
   *wrapper = JS_INVALID_REFERENCE;
 
   JsValueType valueType;
@@ -249,14 +239,12 @@ inline napi_status FindWrapper(napi_env env, JsValueRef obj, JsValueRef* wrapper
     return napi_ok;
   }
 
-  JsPropertyIdRef wrapKey;
-  CHECK_NAPI(GetWrapPropertyId(env, &wrapKey));
-
-  // Use GetOwnPropertyDescriptor (not JsHasProperty) so a stray
-  // "\x01napi_external" defined on Object.prototype (or any other object
-  // up the chain) cannot spoof an unwrap of an otherwise-unwrapped value.
+  // Use GetOwnPropertyDescriptor (not JsHasProperty) so a wrap-info symbol
+  // property defined on Object.prototype (e.g. if some Object.prototype
+  // value were itself wrapped) cannot spoof an unwrap of an otherwise-
+  // unwrapped value via prototype-chain lookup.
   JsValueRef descriptor = JS_INVALID_REFERENCE;
-  CHECK_JSRT(env, JsGetOwnPropertyDescriptor(obj, wrapKey, &descriptor));
+  CHECK_JSRT(env, JsGetOwnPropertyDescriptor(obj, env->wrap_info_property_id, &descriptor));
 
   JsValueType descriptorType;
   CHECK_JSRT(env, JsGetValueType(descriptor, &descriptorType));
@@ -1674,15 +1662,16 @@ napi_status napi_wrap(napi_env env,
   CHECK_JSRT(env, JsCreateExternalObject(
     externalData, ExternalData::Finalize, &external));
 
-  // Attach the external as a hidden own property (non-enumerable so it
-  // does not appear in for..in / Object.keys / JSON.stringify, non-writable
-  // so a stray assignment cannot replace it). Configurable so napi_remove_wrap
-  // can delete it. This keeps the value's prototype chain intact, so
+  // Attach the external as a hidden own property keyed by the env's
+  // wrap-info Symbol. User code cannot construct an equal Symbol from JS,
+  // and even if it discovers ours via Object.getOwnPropertySymbols the
+  // descriptor flags below prevent overwrite-via-assignment. non-writable
+  // blocks `obj[sym] = junk`; non-enumerable for hygiene; configurable so
+  // napi_remove_wrap can delete it. (FindWrapper still gates on
+  // JsHasExternalData as defense-in-depth against re-define attempts.)
+  // This keeps the value's prototype chain intact, so
   // Object.getPrototypeOf(value) still returns whatever the constructor
   // installed.
-  JsPropertyIdRef wrapKey;
-  CHECK_NAPI(GetWrapPropertyId(env, &wrapKey));
-
   JsValueRef descriptor;
   CHECK_JSRT(env, JsCreateObject(&descriptor));
 
@@ -1709,7 +1698,7 @@ napi_status napi_wrap(napi_env env,
   CHECK_JSRT(env, JsSetProperty(descriptor, configurablePid, trueValue, true));
 
   bool defined = false;
-  CHECK_JSRT(env, JsDefineProperty(value, wrapKey, descriptor, &defined));
+  CHECK_JSRT(env, JsDefineProperty(value, env->wrap_info_property_id, descriptor, &defined));
   RETURN_STATUS_IF_FALSE(env, defined, napi_invalid_arg);
 
   if (result != nullptr) {
@@ -1748,11 +1737,8 @@ napi_status napi_remove_wrap(napi_env env, napi_value js_object, void** result) 
   // code redefined it as non-configurable after napi_wrap), bail before
   // detaching the external data so a subsequent napi_unwrap still returns
   // the original data rather than a stale property with cleared external.
-  JsPropertyIdRef wrapKey;
-  CHECK_NAPI(GetWrapPropertyId(env, &wrapKey));
-
   JsValueRef deleteResult = JS_INVALID_REFERENCE;
-  CHECK_JSRT(env, JsDeleteProperty(value, wrapKey, false /* isStrictMode */, &deleteResult));
+  CHECK_JSRT(env, JsDeleteProperty(value, env->wrap_info_property_id, false /* isStrictMode */, &deleteResult));
 
   bool wasDeleted = false;
   CHECK_JSRT(env, JsBooleanToBool(deleteResult, &wasDeleted));

--- a/Core/Node-API/Source/js_native_api_chakra.h
+++ b/Core/Node-API/Source/js_native_api_chakra.h
@@ -13,13 +13,6 @@ struct napi_env__ {
   napi_extended_error_info last_error{ nullptr, nullptr, 0, napi_ok };
   JsValueRef has_own_property_function = JS_INVALID_REFERENCE;
 
-  // Cached property id (keyed by a per-env Symbol) under which napi_wrap
-  // stores the ExternalData wrapper as a hidden own property on the
-  // wrapped value. Using a Symbol-derived id keeps the wrapped value's
-  // prototype chain intact and makes the key unforgeable from JS (user
-  // code cannot construct an equal Symbol). The Symbol itself is pinned
-  // via JsAddRef in Napi::Attach and reclaimed by JsDisposeRuntime; we
-  // never need to dereference it again after deriving the id.
   JsPropertyIdRef wrap_property_id = JS_INVALID_REFERENCE;
 
   const std::thread::id thread_id{std::this_thread::get_id()};

--- a/Core/Node-API/Source/js_native_api_chakra.h
+++ b/Core/Node-API/Source/js_native_api_chakra.h
@@ -13,16 +13,14 @@ struct napi_env__ {
   napi_extended_error_info last_error{ nullptr, nullptr, 0, napi_ok };
   JsValueRef has_own_property_function = JS_INVALID_REFERENCE;
 
-  // Unique Symbol used as a hidden own-property key by napi_wrap to attach
-  // the ExternalData wrapper without mutating the wrapped value's prototype
-  // chain. The Symbol is unforgeable from JS (only this env can name it) and
-  // is pinned via JsAddRef for the env's lifetime; the property id derived
-  // from it is cached so the hot path avoids re-resolving on every call.
-  // JsRelease is intentionally not called in Detach because the Chakra
-  // runtime is already disposed by then (see AppRuntime_Chakra.cpp);
-  // JsDisposeRuntime collects everything regardless.
-  JsValueRef wrap_info_symbol = JS_INVALID_REFERENCE;
-  JsPropertyIdRef wrap_info_property_id = JS_INVALID_REFERENCE;
+  // Cached property id (keyed by a per-env Symbol) under which napi_wrap
+  // stores the ExternalData wrapper as a hidden own property on the
+  // wrapped value. Using a Symbol-derived id keeps the wrapped value's
+  // prototype chain intact and makes the key unforgeable from JS (user
+  // code cannot construct an equal Symbol). The Symbol itself is pinned
+  // via JsAddRef in Napi::Attach and reclaimed by JsDisposeRuntime; we
+  // never need to dereference it again after deriving the id.
+  JsPropertyIdRef wrap_property_id = JS_INVALID_REFERENCE;
 
   const std::thread::id thread_id{std::this_thread::get_id()};
 };

--- a/Core/Node-API/Source/js_native_api_chakra.h
+++ b/Core/Node-API/Source/js_native_api_chakra.h
@@ -13,6 +13,17 @@ struct napi_env__ {
   napi_extended_error_info last_error{ nullptr, nullptr, 0, napi_ok };
   JsValueRef has_own_property_function = JS_INVALID_REFERENCE;
 
+  // Unique Symbol used as a hidden own-property key by napi_wrap to attach
+  // the ExternalData wrapper without mutating the wrapped value's prototype
+  // chain. The Symbol is unforgeable from JS (only this env can name it) and
+  // is pinned via JsAddRef for the env's lifetime; the property id derived
+  // from it is cached so the hot path avoids re-resolving on every call.
+  // JsRelease is intentionally not called in Detach because the Chakra
+  // runtime is already disposed by then (see AppRuntime_Chakra.cpp);
+  // JsDisposeRuntime collects everything regardless.
+  JsValueRef wrap_info_symbol = JS_INVALID_REFERENCE;
+  JsPropertyIdRef wrap_info_property_id = JS_INVALID_REFERENCE;
+
   const std::thread::id thread_id{std::this_thread::get_id()};
 };
 

--- a/Tests/UnitTests/Scripts/tests.ts
+++ b/Tests/UnitTests/Scripts/tests.ts
@@ -1289,12 +1289,7 @@ describe("napi class prototype isolation (#172)", function () {
 
     it("instances inherit from Blob.prototype", function () {
         const blob = new Blob([]);
-        // TODO(#178): Chakra's napi_wrap interposes a hidden external object
-        // into the instance's prototype chain, so Object.getPrototypeOf(blob)
-        // !== Blob.prototype at depth 1 on Chakra. Use isPrototypeOf (chain
-        // walk) until that is fixed.
-        expect(Blob.prototype.isPrototypeOf(blob)).to.equal(true);
-        expect(blob instanceof Blob).to.equal(true);
+        expect(Object.getPrototypeOf(blob)).to.equal(Blob.prototype);
     });
 
     it("plain objects are not instanceof Blob", function () {


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

Fixes #178.

## Context

Chakra's `napi_wrap` inserted the external object into the wrapped value's prototype chain, leaving `Object.getPrototypeOf(new Foo())` returning that external rather than `Foo.prototype`. V8 and JSC don't do this; their `napi_wrap` is transparent to the prototype chain.

## Fix

Attach the external as a hidden own property keyed by `"\x01napi_external"`, defined non-enumerable + non-writable + configurable so it stays out of `for..in` / `Object.keys` / `JSON.stringify`, can't be silently overwritten by assignment, but can still be removed by `napi_remove_wrap`.

`FindWrapper` / `Unwrap` / `napi_remove_wrap` switch from prototype-chain walking / splicing to property lookup / deletion. Public N-API ABI is unchanged.

## Validation

Once this and #177 both land, the workaround in #177's test 4 (`Blob.prototype.isPrototypeOf(blob)`) can be tightened back to `Object.getPrototypeOf(blob) === Blob.prototype`.
