### PR TITLE
[codex] Port remaining Android XR compatibility fixes

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run Connected Android Test
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 33
+          api-level: 35
           target: google_apis
           arch: x86_64
           emulator-options: -no-snapshot -no-window -no-boot-anim -no-audio

--- a/Core/AppRuntime/V8Inspector/Source/V8InspectorAgent.cpp
+++ b/Core/AppRuntime/V8Inspector/Source/V8InspectorAgent.cpp
@@ -419,9 +419,9 @@ namespace Babylon
         }
         v8::Local<v8::String> string_value = v8::Local<v8::String>::Cast(value);
         int len = string_value->Length();
-        std::basic_string<char16_t> buffer(len, '\0');
-        string_value->Write(v8::Isolate::GetCurrent(), reinterpret_cast<uint16_t*>(&buffer[0]), 0, len); // Write expects uint16_t* but the template parameter is char16_t
-        return v8_inspector::StringBuffer::create(v8_inspector::StringView(reinterpret_cast<uint16_t*>(buffer.data()), len));
+        std::vector<uint16_t> buffer(len);
+        string_value->Write(v8::Isolate::GetCurrent(), buffer.data(), 0, len);
+        return v8_inspector::StringBuffer::create(v8_inspector::StringView(buffer.data(), len));
     }
 
     bool AgentImpl::AppendMessage(

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install
 _Follow the steps from [All Development Platforms](#all-development-platforms) before proceeding._
 
 **Required Tools:**
-[Android Studio](https://developer.android.com/studio), [Node.js](https://nodejs.org/en/download/), [Ninja](https://ninja-build.org/)
+[Android Studio](https://developer.android.com/studio) with Android NDK 28.2.13676358 and API level 35 SDK platform installed, [Node.js](https://nodejs.org/en/download/), [Ninja](https://ninja-build.org/)
 
 The minimal requirement target is Android 5.0.
 
@@ -47,7 +47,7 @@ An `.apk` that can be executed on your device or simulator is the output.
 
 First, download the latest release of Ninja, extract the binary, and add it to your system path.
 
-Once you have Android Studio downloaded, you need to set up an Android emulator if you do not have a physical Android device. You can do this by selecting `Tools` -> `Device Manager` and then selecting a device. (We are using Pixel 2 API 27). 
+Once you have Android Studio downloaded, you need to set up an Android emulator if you do not have a physical Android device. You can do this by selecting `Tools` -> `Device Manager` and then selecting a device. (We are using Pixel 2 API 35).
 
 Open the project located at
 `JsRuntimeHost\Tests\UnitTests\Android` with Android Studio. Note that this can take a while to load. (The bottom right corner of the Android Studio window shows you what is currently being loaded.) 

--- a/Tests/UnitTests/Android/app/build.gradle
+++ b/Tests/UnitTests/Android/app/build.gradle
@@ -7,6 +7,9 @@ if (project.hasProperty("jsEngine")) {
     jsEngine = project.property("jsEngine")
 }
 
+def targetApiLevel = 35
+def requiredNdkVersion = project.findProperty("ndkVersion") ?: "28.2.13676358"
+
 def cmakeArguments = [
     "-DANDROID_STL=c++_shared",
     "-DNAPI_JAVASCRIPT_ENGINE=${jsEngine}",
@@ -24,16 +27,13 @@ if (project.hasProperty("importHostCompilers")) {
 
 android {
     namespace 'com.jsruntimehost.unittests'
-    compileSdk 33
-    ndkVersion = "23.1.7779620"
-    if (project.hasProperty("ndkVersion")) {
-        ndkVersion = project.property("ndkVersion")
-    }
+    compileSdk targetApiLevel
+    ndkVersion = requiredNdkVersion
 
     defaultConfig {
         applicationId "com.jsruntimehost.unittests"
         minSdk 21
-        targetSdk 33
+        targetSdk targetApiLevel
         versionCode 1
         versionName "1.0"
 
@@ -45,9 +45,28 @@ android {
             }
         }
 
-        if (project.hasProperty("abiFilters")) {
-            ndk {
-                abiFilters project.getProperty("abiFilters")
+        ndk {
+            def abiFiltersProp = project.findProperty("abiFilters")?.toString()
+            if (abiFiltersProp) {
+                def propFilters = abiFiltersProp.split(',').collect { it.trim() }.findAll { !it.isEmpty() }
+                if (!propFilters.isEmpty()) {
+                    abiFilters(*propFilters)
+                }
+            } else {
+                def requestedAbi = project.findProperty("android.injected.build.abi") ?: System.getenv("ANDROID_ABI")
+                def defaultAbis = []
+                if (requestedAbi) {
+                    defaultAbis = requestedAbi.split(',').collect { it.trim() }.findAll { !it.isEmpty() }
+                }
+                if (defaultAbis.isEmpty()) {
+                    def hostArch = (System.getProperty("os.arch") ?: "").toLowerCase()
+                    if (hostArch.contains("aarch64") || hostArch.contains("arm64")) {
+                        defaultAbis = ['arm64-v8a']
+                    } else {
+                        defaultAbis = ['arm64-v8a', 'x86_64']
+                    }
+                }
+                abiFilters(*defaultAbis)
             }
         }
     }

--- a/Tests/UnitTests/Android/app/src/main/cpp/JNI.cpp
+++ b/Tests/UnitTests/Android/app/src/main/cpp/JNI.cpp
@@ -22,7 +22,11 @@ Java_com_jsruntimehost_unittests_Native_javaScriptTests(JNIEnv* env, jclass claz
     android::global::Initialize(javaVM, context);
 
     Babylon::DebugTrace::EnableDebugTrace(true);
-    Babylon::DebugTrace::SetTraceOutput([](const char* trace) { printf("%s\n", trace); fflush(stdout); });
+    // Emit debug-trace lines straight to logcat under a dedicated "JsRuntimeHost" tag instead of
+    // routing them through AndroidExtensions' StdoutLogger (which forwards all stdout under a single
+    // tag, interleaved with the gtest output). The distinct tag keeps connected-test diagnostics
+    // filterable, e.g. `adb logcat -s JsRuntimeHost`.
+    Babylon::DebugTrace::SetTraceOutput([](const char* trace) { __android_log_print(ANDROID_LOG_INFO, "JsRuntimeHost", "%s", trace); });
 
     auto testResult = RunTests();
 


### PR DESCRIPTION
## Summary

This PR now contains only the Android/runtime-host work that is still missing from `main` after rebasing onto `8cd1429`:

- build and run the Android unit-test app against API level 35;
- align the app's local default with the NDK r28c version already used by CI, while retaining the `-PndkVersion` override;
- accept comma-separated Gradle ABI filters and choose sensible arm64/x86_64 defaults for local and injected builds;
- send native debug-trace output to a dedicated `JsRuntimeHost` logcat tag; and
- replace the inspector's `char16_t`/`uint16_t` type-punning buffer with a correctly typed `std::vector<uint16_t>`.

The Android setup instructions now name the SDK and NDK versions required by this test configuration.

## Work already superseded or removed

- [#118](https://github.com/BabylonJS/JsRuntimeHost/pull/118) (`70ba1e5`) already made the project build with NDK r28c and moved Android CI to it. [#159](https://github.com/BabylonJS/JsRuntimeHost/pull/159) (`49e2980`) migrated CI to GitHub Actions, and [#164](https://github.com/BabylonJS/JsRuntimeHost/pull/164) (`7239f91`) restored the connected-emulator test. This PR therefore only advances that emulator from API 33 to API 35 and aligns the local Gradle default.
- [#133](https://github.com/BabylonJS/JsRuntimeHost/pull/133) (`06d4420`) aligned the supported Android and Windows prebuilts on V8 11. The old three-argument/four-argument inspector `connect` split is no longer applicable and has been removed from this PR.
- The proposed `android-jsc` `250231.0.0` -> `294992.0.0` bump has been removed. `294992` is published under a different Maven path than this repository consumes, and its arm64 binary still has 4 KiB ELF load alignment, so it would not solve Android 15/Android XR 16 KiB page compatibility. [#206](https://github.com/BabylonJS/JsRuntimeHost/pull/206) handles the replacement separately by consuming Bun's pinned Android WebKit/JSC archives for `arm64-v8a` and `x86_64`, relinking them as `libjsc.so`, and raising only the JSC path to API 28.
- The rebase conflict with [#176](https://github.com/BabylonJS/JsRuntimeHost/pull/176) (`f07d991`) was resolved while preserving its Hermes and host-compiler CMake arguments.

## Validation

- `npm ci` in `Tests`.
- Fresh API 35 / NDK `28.2.13676358` arm64 debug builds with both V8 and JavaScriptCore.
- Connected Android tests on an API 35 arm64 emulator with both engines: 1/1 test passed for V8 and 1/1 for JavaScriptCore.
- ELF program-header audit: the newly built JNI library, `libc++_shared.so`, and the supported V8 prebuilt all use 16 KiB load alignment. The legacy JSC prebuilt validated by this branch remains 4 KiB aligned; its intentionally separate replacement in [#206](https://github.com/BabylonJS/JsRuntimeHost/pull/206) produces 16 KiB-aligned `libjsc.so` binaries for `arm64-v8a` and `x86_64`.
- `git diff --check`.

## Scope

This is Android API/toolchain and runtime-host preparation; it is not by itself complete BabylonNative Android XR support. OpenXR loader/manifest wiring, lifecycle and input integration, arm64 Android CI/ELF auditing, and validation on Galaxy XR/XREAL hardware remain separate follow-up work (principally [BabylonNative#1766](https://github.com/BabylonJS/BabylonNative/pull/1766)).
