### PR TITLE
Guard base-n target against parent-project collision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ if(JSRUNTIMEHOST_POLYFILL_XMLHTTPREQUEST)
     set_property(TARGET UrlLib PROPERTY FOLDER Dependencies)
 endif()
 
-if(JSRUNTIMEHOST_POLYFILL_FILE)
+if(JSRUNTIMEHOST_POLYFILL_FILE AND NOT TARGET base-n)
     FetchContent_MakeAvailable_With_Message(base-n)
     add_library(base-n INTERFACE)
     target_include_directories(base-n INTERFACE "${base-n_SOURCE_DIR}/include")


### PR DESCRIPTION
### Problem
When JsRuntimeHost is embedded via FetchContent in a parent project that already declares its own `base-n` INTERFACE target — e.g. **BabylonNative**, which uses base-n for its Window/Canvas polyfills — configuring fails:

```
CMake Error at .../jsruntimehost-src/CMakeLists.txt:150 (add_library):
  add_library cannot create target "base-n" because another target with the
  same name already exists.  The existing target is an interface library
  created in source directory ".../Dependencies".
```

This surfaced now because the merged File / FileReader polyfill (#169) switched its base64 encoder over to the `base-n` dependency, and BabylonNative declares `base-n` before it fetches JsRuntimeHost.

### Fix
Guard the `base-n` block with `NOT TARGET base-n` so that when a parent project already provides the target, JsRuntimeHost adopts it instead of redeclaring. This is the standard CMake subproject pattern and mirrors BabylonNative's own `if(NOT TARGET glslang)` guards. Standalone JsRuntimeHost builds are unaffected (no pre-existing target → block runs as before).

### Validation
- Standalone `NAPI_JAVASCRIPT_ENGINE=Chakra` configure + `UnitTests` build: green, File polyfill + base-n link as before.
- Unblocks BabylonJS/BabylonNative#1706 (the consuming PR that re-pins to merged main).