### PR TITLE
Fix Windows/UWP CI build (MSVC C4875 + JSI include path)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,9 +61,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # A newer MSVC (windows-latest) emits C4875 ("a non-string literal argument to [[gsl::suppress]] is
 # deprecated") from the vendored GSL headers, which several targets compile with warnings-as-error.
 # Suppress this dependency-side deprecation so the Windows build isn't broken by toolchain drift. Must
-# be set before arcana.cpp / Core / Polyfills are added below so they inherit it.
+# be set before arcana.cpp / Core / Polyfills are added below so they inherit it. Scoped to C++ (the
+# warning only fires for GSL's C++ [[gsl::suppress]] attribute); kept directory-wide because GSL is
+# pulled in transitively by many targets (arcana, AppRuntime, the polyfills) and no first-party code
+# uses a non-string [[gsl::suppress]], so this doesn't mask our own warnings.
 if(MSVC)
-    add_compile_options(/wd4875)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/wd4875>)
 endif()
 
 # --------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,14 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# A newer MSVC (windows-latest) emits C4875 ("a non-string literal argument to [[gsl::suppress]] is
+# deprecated") from the vendored GSL headers, which several targets compile with warnings-as-error.
+# Suppress this dependency-side deprecation so the Windows build isn't broken by toolchain drift. Must
+# be set before arcana.cpp / Core / Polyfills are added below so they inherit it.
+if(MSVC)
+    add_compile_options(/wd4875)
+endif()
+
 # --------------------------------------------------
 # Options
 # --------------------------------------------------

--- a/Core/Node-API-JSI/CMakeLists.txt
+++ b/Core/Node-API-JSI/CMakeLists.txt
@@ -57,7 +57,12 @@ if(NOT TARGET jsi)
 endif()
 
 target_include_directories(napi
-    PUBLIC "include")
+    PUBLIC "include"
+    # napi.h pulls in the shared <napi/js_native_api_types.h>, which lives in
+    # Core/Node-API/Include/Shared. That sibling isn't built when the engine is JSI
+    # (Core/CMakeLists.txt selects Node-API-JSI instead of Node-API), so reference the shared
+    # headers directly here -- otherwise the JSI napi fails to compile with C1083.
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../Node-API/Include/Shared")
 
 target_link_libraries(napi
     PUBLIC jsi)

--- a/Core/Node-API-JSI/CMakeLists.txt
+++ b/Core/Node-API-JSI/CMakeLists.txt
@@ -57,12 +57,13 @@ if(NOT TARGET jsi)
 endif()
 
 target_include_directories(napi
-    PUBLIC "include"
-    # napi.h pulls in the shared <napi/js_native_api_types.h>, which lives in
-    # Core/Node-API/Include/Shared. That sibling isn't built when the engine is JSI
-    # (Core/CMakeLists.txt selects Node-API-JSI instead of Node-API), so reference the shared
-    # headers directly here -- otherwise the JSI napi fails to compile with C1083.
-    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../Node-API/Include/Shared")
+    PUBLIC
+        "include"
+        # napi.h pulls in the shared <napi/js_native_api_types.h>, which lives in
+        # Core/Node-API/Include/Shared. That sibling isn't built when the engine is JSI
+        # (Core/CMakeLists.txt selects Node-API-JSI instead of Node-API), so reference the shared
+        # headers directly here -- otherwise the JSI napi fails to compile with C1083.
+        "${CMAKE_CURRENT_SOURCE_DIR}/../Node-API/Include/Shared")
 
 target_link_libraries(napi
     PUBLIC jsi)


### PR DESCRIPTION
Two pre-existing build-config fixes that unbreak the Win32/UWP CI; no functional changes. We hit these
while expanding N-API version support (cf. #116, #183) but they're independent of that work.

- **MSVC `C4875`**: a newer MSVC promotes the deprecated non-string-literal `[[gsl::suppress]]` argument
  (from the vendored GSL headers) to an error under `/WX`, breaking every Win32/UWP build. Suppress it.
- **JSI include path**: add the shared `Core/Node-API/Include/Shared` to the JSI `napi` target so
  `napi.h` can find `<napi/js_native_api_types.h>` (was failing with `C1083`).

---

## Landing sequence

Inter-related N-API PRs; intended order (✅ done / ⏳ pending):

1. ⏳ **BabylonJS/JsRuntimeHost#185** — Fix Windows/UWP CI build (MSVC C4875 + JSI include path). Independent build/toolchain fix; lands first so CI is green under everything below. _(fork twin rebeckerspecialties/JsRuntimeHost#5 — 22/22 green)_  ← **this PR**
2. ⏳ **BabylonJS/JsRuntimeHost#183** — Build napi as a shared library on Android (so in-process addons resolve `napi_*`).
3. ⏳ **BabylonJS/JsRuntimeHost#116** — N-API compliance tests (the Android addons resolve `napi_*` via the shared `libnapi.so` from the step above).
4. ⏳ **N-API v7 across runtimes (V8 / JSC / Chakra)** — #189 (draft) — fork CI twin rebeckerspecialties/JsRuntimeHost#4, 22/22 green.

Motivating RFCs: rebeckerspecialties/JsRuntimeHost#6 (jsc-android → maintained JSC) · rebeckerspecialties/JsRuntimeHost#7 (WebWorker via N-API → Factotum into BabylonNative).
