### PR TITLE
Fix Windows CI: suppress MSVC C4875 from GSL on VS2026 toolset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,14 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# C4875 : a non-string literal argument to [[gsl::suppress]] is deprecated.
+# This originates inside the GSL headers (pulled in transitively via arcana.cpp),
+# not from our code, and surfaces only on newer MSVC toolsets. Suppress it so the
+# /WX builds aren't broken by a deprecation we can't fix in third-party headers.
+if(MSVC)
+    add_compile_options(/wd4875)
+endif()
+
 # --------------------------------------------------
 # Options
 # --------------------------------------------------


### PR DESCRIPTION
## Problem

Every Windows and UWP build is currently failing, e.g. in #190 and any new PR:

```
gsl\util(77,5): error C2220: the following warning is treated as an error
gsl\util(77,5): warning C4875: a non-string literal argument to [[gsl::suppress]]
                is deprecated and will be removed in a future release
[...AppRuntime.vcxproj] [...XMLHttpRequest.vcxproj] [...WebSocket.vcxproj] [...ScriptLoader.vcxproj]
```

This is **not** caused by any source change. The GitHub-hosted `windows-2025` runner image was repointed to a **VS2026 toolset** (internal image name `windows-2025-vs2026`) between Jun 5 and Jun 9. Its newer MSVC introduces **C4875** for the `[[gsl::suppress]]` attribute taking a non-string-literal argument — emitted from inside the **GSL** headers that we pull in transitively via `arcana.cpp`. Because our `warnings_as_errors` builds compile with `/WX`, the deprecation is promoted to a hard error and breaks every Windows/UWP target.

Evidence it's the image, not the code:

| Run | Date | Image behind `windows-2025` |
| --- | --- | --- |
| `main` last green | Jun 5 | `windows-2025` (VS2025) |
| any PR now | Jun 9+ | `windows-2025-vs2026` (VS2026) |

The failing targets (`arcana`, `AppRuntime`, `WebSocket`, `ScriptLoader`, …) are unrelated to each other; the only common factor is GSL + `/WX`.

## Fix

Suppress C4875 for MSVC at the top of the build. The warning is a deprecation inside a third-party header we don't control, so there's nothing to fix in our own code. This mirrors the existing `/wd5205` (WinRT) suppression already present in `warnings_as_errors` in CMakeExtensions.

```cmake
if(MSVC)
    add_compile_options(/wd4875)
endif()
```

## Validation

- Confirmed C4875 originates in `gsl/util` (via arcana), not our sources.
- Verified `/wd4875` is a valid, accepted MSVC option (no `D9002`).
- CI on this branch is the authoritative check that Windows/UWP builds go green again on the VS2026 image.
