### PR TITLE
Fix Windows CI: pin to windows-2022 (VS2022 toolset)

### DIFF
--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Problem

Every Windows/UWP build is failing. GitHub repointed the `windows-latest` label to a **VS2026** toolset (internal image `windows-2025-vs2026`). Its newer MSVC emits **C4875** (`a non-string literal argument to [[gsl::suppress]] is deprecated`) from inside the GSL headers we pull transitively via `arcana.cpp`, and our `/WX` builds promote it to a hard error.

## Fix

Pin the Win32 and UWP jobs to the **windows-2022** runner, which still provides the established VS2022 toolset that doesn't emit C4875. This restores green CI with no source or dependency-graph change, and matches the approach taken in BabylonNative (BabylonJS/BabylonNative#1742).

(Originally proposed as a GSL v4.2.2 bump / `/wd4875` suppression — see the closed #191 — but pinning the runner is the smaller, decoupled fix and keeps us on the known-good toolchain.)

## Validation

CI on this branch confirms the Win32/UWP builds are green again on windows-2022.
