### PR TITLE
UrlLib StatusText for fetch + XMLHttpRequest.statusText (closes #193)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ FetchContent_Declare(llhttp
     EXCLUDE_FROM_ALL)
 FetchContent_Declare(UrlLib
     GIT_REPOSITORY https://github.com/BabylonJS/UrlLib.git
-    GIT_TAG 16c7dfd88cb5e7121cb5b037b44b796b737955d4
+    GIT_TAG 74985214bd4f83a4906b2c62134ac2f9ab89e1ae
     EXCLUDE_FROM_ALL)
 # --------------------------------------------------
 

--- a/Polyfills/Fetch/Source/Fetch.cpp
+++ b/Polyfills/Fetch/Source/Fetch.cpp
@@ -24,6 +24,7 @@ namespace Babylon::Polyfills::Internal
         struct ResponseData
         {
             int statusCode{};
+            std::string statusText;
             std::string url;
             std::vector<std::pair<std::string, std::string>> headers;
             std::vector<std::byte> body;
@@ -49,36 +50,6 @@ namespace Babylon::Polyfills::Internal
             }
 
             throw std::runtime_error{"Unsupported fetch method: " + method + " (only GET and POST are supported)"};
-        }
-
-        const char* StatusText(int statusCode)
-        {
-            switch (statusCode)
-            {
-                case 200: return "OK";
-                case 201: return "Created";
-                case 202: return "Accepted";
-                case 204: return "No Content";
-                case 206: return "Partial Content";
-                case 301: return "Moved Permanently";
-                case 302: return "Found";
-                case 304: return "Not Modified";
-                case 307: return "Temporary Redirect";
-                case 308: return "Permanent Redirect";
-                case 400: return "Bad Request";
-                case 401: return "Unauthorized";
-                case 403: return "Forbidden";
-                case 404: return "Not Found";
-                case 405: return "Method Not Allowed";
-                case 408: return "Request Timeout";
-                case 409: return "Conflict";
-                case 429: return "Too Many Requests";
-                case 500: return "Internal Server Error";
-                case 502: return "Bad Gateway";
-                case 503: return "Service Unavailable";
-                case 504: return "Gateway Timeout";
-                default: return "";
-            }
         }
 
         std::optional<std::string> FindHeader(const ResponseData& data, std::string_view name)
@@ -181,7 +152,7 @@ namespace Babylon::Polyfills::Internal
             const bool ok = data->statusCode >= 200 && data->statusCode < 300;
             response.Set("ok", Napi::Boolean::New(env, ok));
             response.Set("status", Napi::Number::New(env, data->statusCode));
-            response.Set("statusText", Napi::String::New(env, StatusText(data->statusCode)));
+            response.Set("statusText", Napi::String::New(env, data->statusText));
             response.Set("url", Napi::String::New(env, data->url));
             response.Set("redirected", Napi::Boolean::New(env, false));
             response.Set("type", Napi::String::New(env, "basic"));
@@ -355,6 +326,7 @@ namespace Babylon::Polyfills::Internal
 
                                 auto data = std::make_shared<ResponseData>();
                                 data->statusCode = status;
+                                data->statusText = std::string{request->StatusText()};
                                 data->url = std::string{request->ResponseUrl()};
                                 for (const auto& header : request->GetAllResponseHeaders())
                                 {

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.cpp
@@ -80,6 +80,7 @@ namespace Babylon::Polyfills::Internal
                 InstanceAccessor("responseType", &XMLHttpRequest::GetResponseType, &XMLHttpRequest::SetResponseType),
                 InstanceAccessor("responseURL", &XMLHttpRequest::GetResponseURL, nullptr),
                 InstanceAccessor("status", &XMLHttpRequest::GetStatus, nullptr),
+                InstanceAccessor("statusText", &XMLHttpRequest::GetStatusText, nullptr),
                 InstanceMethod("getAllResponseHeaders", &XMLHttpRequest::GetAllResponseHeaders),
                 InstanceMethod("getResponseHeader", &XMLHttpRequest::GetResponseHeader),
                 InstanceMethod("setRequestHeader", &XMLHttpRequest::SetRequestHeader),
@@ -147,6 +148,18 @@ namespace Babylon::Polyfills::Internal
     Napi::Value XMLHttpRequest::GetStatus(const Napi::CallbackInfo&)
     {
         return Napi::Value::From(Env(), arcana::underlying_cast(m_request.StatusCode()));
+    }
+
+    Napi::Value XMLHttpRequest::GetStatusText(const Napi::CallbackInfo&)
+    {
+        // Per the XHR spec, statusText is the empty string until a response is available
+        // (status 0 means UNSENT/OPENED or a network error).
+        if (arcana::underlying_cast(m_request.StatusCode()) == 0)
+        {
+            return Napi::String::New(Env(), "");
+        }
+
+        return Napi::String::New(Env(), std::string{m_request.StatusText()});
     }
 
     Napi::Value XMLHttpRequest::GetResponseHeader(const Napi::CallbackInfo& info)

--- a/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
+++ b/Polyfills/XMLHttpRequest/Source/XMLHttpRequest.h
@@ -34,6 +34,7 @@ namespace Babylon::Polyfills::Internal
         Napi::Value GetAllResponseHeaders(const Napi::CallbackInfo& info);
         Napi::Value GetResponseURL(const Napi::CallbackInfo& info);
         Napi::Value GetStatus(const Napi::CallbackInfo& info);
+        Napi::Value GetStatusText(const Napi::CallbackInfo& info);
 
         void AddEventListener(const Napi::CallbackInfo& info);
         void RemoveEventListener(const Napi::CallbackInfo& info);

--- a/Tests/UnitTests/Scripts/tests.ts
+++ b/Tests/UnitTests/Scripts/tests.ts
@@ -121,6 +121,13 @@ describe("XMLHTTPRequest", function () {
         expect(xhr.status).to.equal(404);
     });
 
+    it("should expose statusText", async function () {
+        const okXhr = await createRequest("GET", "https://github.com/");
+        expect(okXhr.statusText).to.equal("OK");
+        const notFoundXhr = await createRequest("GET", "https://github.com/babylonJS/BabylonNative404");
+        expect(notFoundXhr.statusText).to.equal("Not Found");
+    });
+
     it("should fire 'error' event for a remote URL that returns HTTP 404", async function () {
         // Regression test: previously the success-only continuation in XMLHttpRequest::Send
         // skipped 'error' on async failures including non-2xx HTTP responses, so onerror
@@ -254,8 +261,10 @@ describe("fetch", function () {
     });
 
     it("should expose statusText", async function () {
-        const response = await fetch("https://github.com/babylonJS/BabylonNative404");
-        expect(response.statusText).to.equal("Not Found");
+        const okResponse = await fetch("https://github.com/");
+        expect(okResponse.statusText).to.equal("OK");
+        const notFoundResponse = await fetch("https://github.com/babylonJS/BabylonNative404");
+        expect(notFoundResponse.statusText).to.equal("Not Found");
     });
 
     it("text() should return the body as a string", async function () {


### PR DESCRIPTION
Closes #193.

## Summary

Now that [BabylonJS/UrlLib#30](https://github.com/BabylonJS/UrlLib/pull/30) is merged, `UrlRequest::StatusText()` (the wire reason phrase where available, else a canonical code→text fallback table) is available upstream:

- **Fetch**: drop the private status-code→text table in `Fetch.cpp` and read `request.StatusText()` into `Response.statusText`.
- **XMLHttpRequest**: expose `statusText` (previously absent) — now free from the same UrlLib API.
- Adds `fetch` + `XMLHttpRequest` `statusText` unit tests (`OK` / `Not Found`).

The `UrlLib` pin is bumped to `BabylonJS/UrlLib` `74985214` (the UrlLib#30 merge commit).

**Verified locally:** `Fetch` and `XMLHttpRequest` polyfill libraries build clean against the bumped UrlLib pin (Win32 Chakra). Unit tests (incl. the new `statusText` tests) run in CI.

## Notes

- `statusText` is consumed purely to decorate error messages (nothing branches on it), so the concrete win is e.g. `404 Not Found` instead of `404 undefined`. The code→text fallback table in UrlLib is the right shape for how the value is used (real browsers return `""` over HTTP/2).
- Apple/Android currently get their reason phrase from UrlLib's fallback table (their native HTTP stacks don't surface the raw phrase); wiring Android's `getResponseMessage()` is a possible follow-up.
