### PR TITLE
Node-API (Chakra): fix heap corruption when an ObjectWrap constructor throws

### DIFF
--- a/Core/Node-API/Source/js_native_api_chakra.cc
+++ b/Core/Node-API/Source/js_native_api_chakra.cc
@@ -172,6 +172,27 @@ class ExternalCallback {
 
     napi_value result = externalCallback->_cb(
       externalCallback->_env, reinterpret_cast<napi_callback_info>(&cbInfo));
+
+    // If a constructor (construct call) left a pending JS exception, the C++
+    // ObjectWrap instance was already destroyed by stack unwinding inside the
+    // callback, but the wrap finalizer registered by napi_wrap() is still
+    // attached to `this`. The addon-api ~ObjectWrap() cannot detach it here
+    // because napi_get_reference_value() returns null for the wrap's weak
+    // (refcount 0) reference. Detach the wrap now so a later GC does not run
+    // the finalizer on the freed native instance (use-after-free / heap
+    // corruption). The pending exception is preserved across the cleanup.
+    if (isConstructCall) {
+      bool hasException = false;
+      if (JsHasException(&hasException) == JsNoError && hasException) {
+        JsValueRef exception = JS_INVALID_REFERENCE;
+        if (JsGetAndClearException(&exception) == JsNoError) {
+          napi_remove_wrap(externalCallback->_env,
+            reinterpret_cast<napi_value>(arguments[0]), nullptr);
+          JsSetException(exception);
+        }
+      }
+    }
+
     return reinterpret_cast<JsValueRef>(result);
   }
 
@@ -1748,9 +1769,11 @@ napi_status napi_remove_wrap(napi_env env, napi_value js_object, void** result) 
   CHECK_JSRT(env, JsSetExternalData(wrapper, nullptr));
 
   if (externalData != nullptr) {
-    *result = externalData->Data();
+    if (result != nullptr) {
+      *result = externalData->Data();
+    }
     delete externalData;
-  } else {
+  } else if (result != nullptr) {
     *result = nullptr;
   }
 

--- a/Tests/UnitTests/Scripts/tests.ts
+++ b/Tests/UnitTests/Scripts/tests.ts
@@ -1492,7 +1492,7 @@ describe("TextDecoder", function () {
     });
 
     it("throwing from the constructor repeatedly does not corrupt native state", function () {
-        // Regression for a ChakraCore N-API ObjectWrap bug: when a wrapped
+        // Regression for a Chakra N-API ObjectWrap bug: when a wrapped
         // constructor throws, the native instance is destroyed during stack
         // unwinding but the wrap finalizer stayed attached to `this`, so a
         // later GC ran the finalizer on freed memory (heap corruption). Throw

--- a/Tests/UnitTests/Scripts/tests.ts
+++ b/Tests/UnitTests/Scripts/tests.ts
@@ -1490,6 +1490,20 @@ describe("TextDecoder", function () {
         expect(result).to.equal("H\0i");
         expect(result.length).to.equal(3);
     });
+
+    it("throwing from the constructor repeatedly does not corrupt native state", function () {
+        // Regression for a ChakraCore N-API ObjectWrap bug: when a wrapped
+        // constructor throws, the native instance is destroyed during stack
+        // unwinding but the wrap finalizer stayed attached to `this`, so a
+        // later GC ran the finalizer on freed memory (heap corruption). Throw
+        // many times to create many dangling wraps, then allocate/decode to
+        // exercise the heap and surface any corruption within this test run.
+        for (let i = 0; i < 100; ++i) {
+            expect(() => new TextDecoder("utf-16")).to.throw();
+        }
+        const decoder = new TextDecoder("utf-8");
+        expect(decoder.decode(new Uint8Array([79, 75]))).to.equal("OK");
+    });
 });
 
 describe("TextEncoder", function () {


### PR DESCRIPTION
## What

Fixes a heap corruption in the Chakra Node-API implementation when an `ObjectWrap`-based constructor throws.

Split out of https://github.com/BabylonJS/JsRuntimeHost/pull/198 as an independent fix, per review.

## Problem

When a wrapped (`napi_wrap`) constructor throws, the C++ `ObjectWrap` instance is destroyed by stack unwinding inside the callback, but the wrap finalizer registered by `napi_wrap()` stays attached to `this`. `~ObjectWrap()` cannot detach it, because `napi_get_reference_value()` returns null for the wrap's weak (refcount 0) reference. A later GC then runs the finalizer on the freed native instance — a use-after-free that surfaces as non-deterministic `STATUS_HEAP_CORRUPTION` (`0xC0000374`).

## Fix

`Core/Node-API/Source/js_native_api_chakra.cc`:
- In `ExternalCallback`, after a construct call that left a pending JS exception, detach the wrap (`napi_remove_wrap`) before returning, then re-set the exception so it is preserved across the cleanup.
- Guard `napi_remove_wrap` against a `nullptr` `result` out-param (the finalizer-cleanup call above passes `nullptr`), so it no longer dereferences a null pointer.

## Test

Adds a regression test (`Tests/UnitTests/Scripts/tests.ts`) that throws from a wrapped constructor 100× to create many dangling wraps, then allocates/decodes to exercise the heap and surface any corruption within the run. It uses `TextDecoder` as a convenient throwing wrapped constructor; the test passes on `main`'s existing `TextDecoder` behavior and is independent of the TextDecoder label change in #198.

## Verification

Reliably reproduced as `STATUS_HEAP_CORRUPTION` on Chakra (Win32 x64/x86) before the fix; passes after.
