### PR TITLE
Drop redundant Linux compiler env from build-linux.yml

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -24,9 +24,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      CC: ${{ inputs.cc }}
-      CXX: ${{ inputs.cxx }}
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Context

`build-linux.yml` set job-level `CC`/`CXX` env alongside the `-D CMAKE_C_COMPILER` / `-D CMAKE_CXX_COMPILER` configure flags. The `-D` flags already select the compiler for both the gcc and clang matrix legs, so the env block was redundant.

No behavior change: on the parallel UrlLib CI cleanup both the gcc and clang Linux jobs stayed green with the env removed. The Run Tests step's `env` (`TSAN_OPTIONS` / `JSC_useConcurrentGC`) is untouched.

Part of a small cross-repo consistency pass — UrlLib landed the same cleanup. BabylonNative was checked and intentionally left alone: its `build-linux.yml` env is load-bearing there (its configure passes no `-D` compiler flags).

[Created by Copilot on behalf of @bghgary]
