### PR TITLE
Drain deferred V8 N-API finalizers after dispatch

### DIFF
--- a/Core/AppRuntime/Include/Babylon/AppRuntime.h
+++ b/Core/AppRuntime/Include/Babylon/AppRuntime.h
@@ -76,6 +76,10 @@ namespace Babylon
         // queue explicitly (Napi::DrainJobs / JS_ExecutePendingJob).
         void DrainMicrotasks(Napi::Env env);
 
+        // Engine-specific maintenance that should run once after a complete
+        // dispatcher turn, rather than after each callback in that turn.
+        void DrainPostDispatchWork(Napi::Env env);
+
         Options m_options;
 
         class Impl;

--- a/Core/AppRuntime/Source/AppRuntime.cpp
+++ b/Core/AppRuntime/Source/AppRuntime.cpp
@@ -84,7 +84,10 @@ namespace Babylon
 
         while (!m_impl->m_cancelSource.cancelled())
         {
-            m_impl->m_dispatcher.blocking_tick(m_impl->m_cancelSource);
+            if (m_impl->m_dispatcher.blocking_tick(m_impl->m_cancelSource))
+            {
+                DrainPostDispatchWork(env);
+            }
         }
 
         // The dispatcher can be non-empty if something is dispatched after cancellation.

--- a/Core/AppRuntime/Source/AppRuntime_Chakra.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_Chakra.cpp
@@ -78,4 +78,8 @@ namespace Babylon
         // JsSetPromiseContinuationCallback hook (see RunEnvironmentTier).
         // No explicit pump needed here.
     }
+
+    void AppRuntime::DrainPostDispatchWork(Napi::Env)
+    {
+    }
 }

--- a/Core/AppRuntime/Source/AppRuntime_Hermes.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_Hermes.cpp
@@ -25,4 +25,8 @@ namespace Babylon
         // observes the same "between turns" semantics it gets on V8/Chakra.
         Napi::DrainJobs(env);
     }
+
+    void AppRuntime::DrainPostDispatchWork(Napi::Env)
+    {
+    }
 }

--- a/Core/AppRuntime/Source/AppRuntime_JSI.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_JSI.cpp
@@ -50,4 +50,8 @@ namespace Babylon
     {
         // JSI/V8 backed JSI auto-drains microtasks per scope.
     }
+
+    void AppRuntime::DrainPostDispatchWork(Napi::Env)
+    {
+    }
 }

--- a/Core/AppRuntime/Source/AppRuntime_JavaScriptCore.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_JavaScriptCore.cpp
@@ -28,4 +28,8 @@ namespace Babylon
     {
         // JavaScriptCore drains microtasks automatically at script boundaries.
     }
+
+    void AppRuntime::DrainPostDispatchWork(Napi::Env)
+    {
+    }
 }

--- a/Core/AppRuntime/Source/AppRuntime_QuickJS.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_QuickJS.cpp
@@ -64,4 +64,8 @@ namespace Babylon
         {
         }
     }
+
+    void AppRuntime::DrainPostDispatchWork(Napi::Env)
+    {
+    }
 }

--- a/Core/AppRuntime/Source/AppRuntime_V8.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_V8.cpp
@@ -113,9 +113,11 @@ namespace Babylon
         isolate->Dispose();
     }
 
-    void AppRuntime::DrainMicrotasks(Napi::Env)
+    void AppRuntime::DrainMicrotasks(Napi::Env env)
     {
         // V8 auto-drains microtasks at the end of each script/callback when
-        // using the default MicrotasksPolicy.  No explicit pump needed.
+        // using the default MicrotasksPolicy. N-API finalizers deferred by a
+        // V8 garbage collection still require a safe host callback boundary.
+        Napi::DrainFinalizers(env);
     }
 }

--- a/Core/AppRuntime/Source/AppRuntime_V8.cpp
+++ b/Core/AppRuntime/Source/AppRuntime_V8.cpp
@@ -113,11 +113,15 @@ namespace Babylon
         isolate->Dispose();
     }
 
-    void AppRuntime::DrainMicrotasks(Napi::Env env)
+    void AppRuntime::DrainMicrotasks(Napi::Env)
     {
-        // V8 auto-drains microtasks at the end of each script/callback when
-        // using the default MicrotasksPolicy. N-API finalizers deferred by a
-        // V8 garbage collection still require a safe host callback boundary.
+        // V8 auto-drains microtasks at the end of each script/callback.
+    }
+
+    void AppRuntime::DrainPostDispatchWork(Napi::Env env)
+    {
+        // N-API finalizers deferred by a V8 garbage collection require a safe
+        // host boundary, but should not monopolize a dispatcher turn.
         Napi::DrainFinalizers(env);
     }
 }

--- a/Core/Node-API/Include/Engine/V8/napi/env.h
+++ b/Core/Node-API/Include/Engine/V8/napi/env.h
@@ -52,6 +52,8 @@ namespace Napi
 
   void Detach(Napi::Env);
 
+  void DrainFinalizers(Napi::Env);
+
   Napi::Value Eval(Napi::Env env, const char* source, const char* sourceUrl);
 
   v8::Local<v8::Context> GetContext(Napi::Env);

--- a/Core/Node-API/Source/env_v8.cc
+++ b/Core/Node-API/Source/env_v8.cc
@@ -2,8 +2,15 @@
 #include <napi/js_native_api_types.h>
 #include "js_native_api_v8.h"
 
+#include <chrono>
+
 namespace Napi
 {
+  namespace
+  {
+    constexpr auto FinalizerDrainBudget{std::chrono::milliseconds{8}};
+  }
+
   Env Attach(v8::Local<v8::Context> isolate)
   {
     // second argument is module version
@@ -19,13 +26,20 @@ namespace Napi
   void DrainFinalizers(Env env)
   {
     napi_env env_ptr{env};
+    const auto start = std::chrono::steady_clock::now();
 
-    // Finalizers can mutate this queue, so continue until it is empty.
+    // Finalizers can mutate this queue. Bound each dispatcher turn so a large
+    // batch cannot monopolize the runtime thread.
     while (!env_ptr->pending_finalizers.empty())
     {
       auto* finalizer = *env_ptr->pending_finalizers.begin();
       env_ptr->pending_finalizers.erase(finalizer);
       finalizer->Finalize();
+
+      if (std::chrono::steady_clock::now() - start >= FinalizerDrainBudget)
+      {
+        break;
+      }
     }
   }
 

--- a/Core/Node-API/Source/env_v8.cc
+++ b/Core/Node-API/Source/env_v8.cc
@@ -16,6 +16,19 @@ namespace Napi
     env_ptr->DeleteMe();
   }
 
+  void DrainFinalizers(Env env)
+  {
+    napi_env env_ptr{env};
+
+    // Finalizers can mutate this queue, so continue until it is empty.
+    while (!env_ptr->pending_finalizers.empty())
+    {
+      auto* finalizer = *env_ptr->pending_finalizers.begin();
+      env_ptr->pending_finalizers.erase(finalizer);
+      finalizer->Finalize();
+    }
+  }
+
   v8::Local<v8::Context> GetContext(Env env)
   {
     napi_env env_ptr{env};

--- a/Tests/UnitTests/Android/app/src/main/cpp/CMakeLists.txt
+++ b/Tests/UnitTests/Android/app/src/main/cpp/CMakeLists.txt
@@ -23,6 +23,9 @@ add_library(UnitTestsJNI SHARED
 
 target_compile_definitions(UnitTestsJNI PRIVATE JSRUNTIMEHOST_PLATFORM="${JSRUNTIMEHOST_PLATFORM}")
 target_compile_definitions(UnitTestsJNI PRIVATE ARCANA_TEST_HOOKS)
+if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8")
+    target_compile_definitions(UnitTestsJNI PRIVATE JSRUNTIMEHOST_NAPI_ENGINE_V8)
+endif()
 
 target_include_directories(UnitTestsJNI
     PRIVATE ${UNIT_TESTS_DIR})

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -51,6 +51,9 @@ target_compile_definitions(UnitTests PRIVATE JSRUNTIMEHOST_PLATFORM="${JSRUNTIME
 if(NAPI_JAVASCRIPT_ENGINE STREQUAL "JSI")
     target_compile_definitions(UnitTests PRIVATE JSRUNTIMEHOST_NAPI_ENGINE_JSI)
 endif()
+if(NAPI_JAVASCRIPT_ENGINE STREQUAL "V8")
+    target_compile_definitions(UnitTests PRIVATE JSRUNTIMEHOST_NAPI_ENGINE_V8)
+endif()
 
 target_link_libraries(UnitTests
     PRIVATE AppRuntime

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -22,6 +22,10 @@
 #include <iostream>
 #include <thread>
 
+#if defined(JSRUNTIMEHOST_NAPI_ENGINE_V8)
+#include <napi/env.h>
+#endif
+
 namespace
 {
     const char* EnumToString(Babylon::Polyfills::Console::LogLevel logLevel)
@@ -278,6 +282,36 @@ TEST(AppRuntime, DestroyDoesNotDeadlock)
 
     testThread.join();
 }
+
+#if defined(JSRUNTIMEHOST_NAPI_ENGINE_V8)
+TEST(AppRuntime, V8FinalizersDrainAfterDispatch)
+{
+    constexpr size_t ExternalCount{32};
+    std::atomic<size_t> finalized{};
+    std::promise<size_t> observed;
+
+    Babylon::AppRuntime runtime{};
+    runtime.Dispatch([&finalized](Napi::Env env) {
+        for (size_t index{}; index < ExternalCount; ++index)
+        {
+            Napi::External<std::atomic<size_t>>::New(
+                env,
+                &finalized,
+                [](Napi::Env, std::atomic<size_t>* count) {
+                    count->fetch_add(1, std::memory_order_relaxed);
+                });
+        }
+    });
+    runtime.Dispatch([](Napi::Env env) {
+        Napi::GetContext(env)->GetIsolate()->LowMemoryNotification();
+    });
+    runtime.Dispatch([&finalized, &observed](Napi::Env) {
+        observed.set_value(finalized.load(std::memory_order_relaxed));
+    });
+
+    EXPECT_EQ(observed.get_future().get(), ExternalCount);
+}
+#endif
 
 // The V8JSI Node-API shim does not implement napi_create_dataview /
 // napi_get_dataview_info (its DataView::New throws "TODO"), so this native test

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -288,10 +288,12 @@ TEST(AppRuntime, V8FinalizersDrainAfterDispatch)
 {
     constexpr size_t ExternalCount{32};
     std::atomic<size_t> finalized{};
+    std::promise<void> created;
+    std::promise<void> collectionRequested;
     std::promise<size_t> observed;
 
     Babylon::AppRuntime runtime{};
-    runtime.Dispatch([&finalized](Napi::Env env) {
+    runtime.Dispatch([&finalized, &created](Napi::Env env) {
         for (size_t index{}; index < ExternalCount; ++index)
         {
             Napi::External<std::atomic<size_t>>::New(
@@ -301,15 +303,70 @@ TEST(AppRuntime, V8FinalizersDrainAfterDispatch)
                     count->fetch_add(1, std::memory_order_relaxed);
                 });
         }
+        created.set_value();
     });
-    runtime.Dispatch([](Napi::Env env) {
+    created.get_future().wait();
+
+    runtime.Dispatch([&collectionRequested](Napi::Env env) {
         Napi::GetContext(env)->GetIsolate()->LowMemoryNotification();
+        collectionRequested.set_value();
     });
+    collectionRequested.get_future().wait();
+
     runtime.Dispatch([&finalized, &observed](Napi::Env) {
         observed.set_value(finalized.load(std::memory_order_relaxed));
     });
 
     EXPECT_EQ(observed.get_future().get(), ExternalCount);
+}
+
+TEST(AppRuntime, V8FinalizerDrainYieldsBetweenDispatcherTurns)
+{
+    constexpr size_t ExternalCount{16};
+    std::atomic<size_t> finalized{};
+    std::promise<void> created;
+    std::promise<void> collectionRequested;
+
+    Babylon::AppRuntime runtime{};
+    runtime.Dispatch([&](Napi::Env env) {
+        for (size_t index{}; index < ExternalCount; ++index)
+        {
+            Napi::External<std::atomic<size_t>>::New(
+                env,
+                &finalized,
+                [](Napi::Env, std::atomic<size_t>* count) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds{2});
+                    count->fetch_add(1, std::memory_order_relaxed);
+                });
+        }
+        created.set_value();
+    });
+    created.get_future().wait();
+
+    runtime.Dispatch([&](Napi::Env env) {
+        Napi::GetContext(env)->GetIsolate()->LowMemoryNotification();
+        collectionRequested.set_value();
+    });
+    collectionRequested.get_future().wait();
+
+    const auto observeFinalized = [&]() {
+        std::promise<size_t> observed;
+        auto future = observed.get_future();
+        runtime.Dispatch([&](Napi::Env) {
+            observed.set_value(finalized.load(std::memory_order_relaxed));
+        });
+        return future.get();
+    };
+
+    auto observed = observeFinalized();
+    EXPECT_GT(observed, 0u);
+    EXPECT_LT(observed, ExternalCount);
+
+    for (size_t turn{}; turn < ExternalCount && observed < ExternalCount; ++turn)
+    {
+        observed = observeFinalized();
+    }
+    EXPECT_EQ(observed, ExternalCount);
 }
 #endif
 


### PR DESCRIPTION
## Summary

Drain deferred V8 N-API finalizers at a safe host boundary, with an 8 ms budget per dispatcher turn.

V8 weak callbacks enqueue non-experimental N-API finalizers for a safe second pass. JsRuntimeHost did not run that pass, so collected wrappers retained native resources until runtime teardown. This is independent of Dawn, WebGPU, and application rendering code.

## Reproduction

The profiling workload uses four packaged VRM files (from https://github.com/PolygonalMind/100Avatars ), loaded through the browser-shaped Blob path, with four thin instances per avatar. It replaces the batch ten times after 180 rendered frames:

```js
const engine = new BABYLON.NativeEngine();
const scene = new BABYLON.Scene(engine);
scene.createDefaultCamera(true, true, true);
scene.createDefaultLight(true);
engine.runRenderLoop(() => scene.render());

const avatarUrls = [
    "app:///Assets/avatar-a.vrm",
    "app:///Assets/avatar-b.vrm",
    "app:///Assets/avatar-c.vrm",
    "app:///Assets/avatar-d.vrm",
];

const matrices = new Float32Array(4 * 16);
for (let index = 0; index < 4; ++index) {
    BABYLON.Matrix.Translation((index - 1.5) * 1.5, 0, 0).copyToArray(matrices, index * 16);
}

const waitFrames = (count) =>
    new Promise((resolve) => {
        const observer = scene.onAfterRenderObservable.add(() => {
            if (--count === 0) {
                scene.onAfterRenderObservable.remove(observer);
                resolve();
            }
        });
    });

(async () => {
    let containers = [];
    for (let cycle = 0; cycle < 10; ++cycle) {
        for (const container of containers) {
            container.dispose();
        }
        containers = [];

        for (const url of avatarUrls) {
            const response = await fetch(url);
            const blob = await response.blob();
            const objectUrl = URL.createObjectURL(blob);
            try {
                const container = await BABYLON.SceneLoader.LoadAssetContainerAsync(
                    "",
                    objectUrl,
                    scene,
                    undefined,
                    ".glb"
                );
                container.addAllToScene();
                for (const mesh of container.meshes) {
                    if (mesh.getTotalVertices() > 0) {
                        mesh.thinInstanceSetBuffer("matrix", matrices, 16, true);
                    }
                }
                containers.push(container);
            } finally {
                URL.revokeObjectURL(objectUrl);
            }
        }

        await waitFrames(180);
    }
})();
```

The measured files were four distinct 6-10 MB VRMs from [PolygonalMind/100Avatars](https://github.com/PolygonalMind/100Avatars/tree/master/100Avatars_200).

## Validation

- Current main reached about 2 GB RSS / 1.9 GB native heap with the deferred queue undrained.
- Draining the queue kept the same workload near 429 MB RSS at 50 seconds.
- Per-turn budgeting reduced the original 109.49 ms maximum drain to short slices. After removing an unrelated synchronous resource flush in the application finalizer, the 10-cycle run measured p95 8.00 ms, p99 8.06 ms, and max 8.36 ms.
- V8 connected suite: 8 tests passed, including deterministic coverage that the queue yields between turns and then drains completely.
- Android HWASan soak: 600,064 transient wrappers completed with bounded memory and no finding.
