### PR TITLE
Fix setInterval starving the JS dispatch queue

### DIFF
--- a/Polyfills/Scheduling/Source/TimeoutDispatcher.cpp
+++ b/Polyfills/Scheduling/Source/TimeoutDispatcher.cpp
@@ -208,40 +208,67 @@ namespace Babylon::Polyfills::Internal
 
             if (function)
             {
-                function->Call({});
+                try
+                {
+                    function->Call({});
+                }
+                catch (const Napi::Error& error)
+                {
+                    // A throwing tick must not silently stop the interval, which
+                    // is both the pre-existing behavior and what browsers do.
+                    // Re-arm first, then re-raise the error as a pending JS
+                    // exception so JsRuntime::Dispatch still surfaces it.
+                    if (interval.has_value())
+                    {
+                        Rearm(id, sequence, scheduledTime, *interval);
+                    }
+
+                    error.ThrowAsJavaScriptException();
+                    return;
+                }
             }
 
-            if (!interval.has_value())
+            if (interval.has_value())
             {
-                return;
-            }
-
-            // Re-arm only now that the callback has completed. Anchor the next
-            // deadline to the previous scheduled time so a long-running callback
-            // does not accumulate drift, but never schedule into the past.
-            std::unique_lock<std::recursive_mutex> lk{m_mutex};
-            const auto it = m_idMap.find(id);
-            if (it == m_idMap.end() || it->second->sequence != sequence)
-            {
-                // Cleared from within its own callback.
-                return;
-            }
-
-            const auto now = Now();
-            auto nextTime = scheduledTime + *interval;
-            if (nextTime < now)
-            {
-                nextTime = now;
-            }
-
-            const auto earliestTime = m_timeMap.empty() ? TimePoint::max() : m_timeMap.cbegin()->second->time;
-            it->second->time = nextTime;
-            m_timeMap.insert({nextTime, it->second.get()});
-
-            if (nextTime <= earliestTime)
-            {
-                m_condVariable.notify_one();
+                Rearm(id, sequence, scheduledTime, *interval);
             }
         });
+    }
+
+    // Re-arms a repeating timeout. Called on the JS thread once the callback has
+    // returned, so a repeating timeout can never have more than one invocation
+    // queued at a time.
+    void TimeoutDispatcher::Rearm(TimeoutId id, uint64_t sequence, TimePoint scheduledTime, std::chrono::milliseconds interval)
+    {
+        std::unique_lock<std::recursive_mutex> lk{m_mutex};
+
+        const auto it = m_idMap.find(id);
+        if (it == m_idMap.end() || it->second->sequence != sequence)
+        {
+            // Cleared from within its own callback, or the id has since been
+            // reused by an unrelated timeout.
+            return;
+        }
+
+        // Anchor the next deadline to the previous scheduled time so that a long
+        // running callback does not accumulate drift, but never schedule into the
+        // past.
+        const auto now = Now();
+        auto nextTime = scheduledTime + interval;
+        if (nextTime < now)
+        {
+            nextTime = now;
+        }
+
+        const auto earliestTime = m_timeMap.empty() ? TimePoint::max() : m_timeMap.cbegin()->second->time;
+        it->second->time = nextTime;
+        m_timeMap.insert({nextTime, it->second.get()});
+
+        if (nextTime <= earliestTime)
+        {
+            // The timer thread parks while m_timeMap is empty, which is the case
+            // whenever this timeout was the only one pending.
+            m_condVariable.notify_one();
+        }
     }
 }

--- a/Polyfills/Scheduling/Source/TimeoutDispatcher.cpp
+++ b/Polyfills/Scheduling/Source/TimeoutDispatcher.cpp
@@ -19,6 +19,10 @@ namespace Babylon::Polyfills::Internal
     {
         TimeoutId id;
 
+        // Distinguishes this timeout from a later one that happens to reuse the
+        // same id, so an in-flight callback can never re-arm its replacement.
+        uint64_t sequence;
+
         // Make this non-shared when JsRuntime::Dispatch supports it.
         std::shared_ptr<Napi::FunctionReference> function;
 
@@ -26,8 +30,9 @@ namespace Babylon::Polyfills::Internal
 
         std::optional<std::chrono::milliseconds> interval;
 
-        Timeout(TimeoutId id, std::shared_ptr<Napi::FunctionReference> function, TimePoint time, std::optional<std::chrono::milliseconds> interval)
+        Timeout(TimeoutId id, uint64_t sequence, std::shared_ptr<Napi::FunctionReference> function, TimePoint time, std::optional<std::chrono::milliseconds> interval)
             : id{id}
+            , sequence{sequence}
             , function{std::move(function)}
             , time{time}
             , interval{interval}
@@ -77,7 +82,7 @@ namespace Babylon::Polyfills::Internal
         }
         const auto earliestTime = m_timeMap.empty() ? TimePoint::max() : m_timeMap.cbegin()->second->time;
         const auto time = Now() + delay;
-        const auto result = m_idMap.insert({id, std::make_unique<Timeout>(id, std::move(function), time, repeat ? std::make_optional<std::chrono::milliseconds>(delay) : std::nullopt)});
+        const auto result = m_idMap.insert({id, std::make_unique<Timeout>(id, ++m_lastSequence, std::move(function), time, repeat ? std::make_optional<std::chrono::milliseconds>(delay) : std::nullopt)});
         m_timeMap.insert({time, result.first->second.get()});
 
         if (time <= earliestTime)
@@ -150,14 +155,18 @@ namespace Babylon::Polyfills::Internal
             while (!m_timeMap.empty() && m_timeMap.begin()->second->time == nextTimePoint)
             {
                 const auto id = m_timeMap.begin()->second->id;
+                const auto sequence = m_timeMap.begin()->second->sequence;
                 m_timeMap.erase(m_timeMap.begin());
-                const auto repeat = m_idMap[id]->interval.has_value();
-                if (repeat)
-                {
-                    const auto timeout = std::move(m_idMap.extract(id).mapped());
-                    DispatchImpl(std::move(timeout->function), *timeout->interval, true, timeout->id);
-                }
-                CallFunction(id);
+
+                // Repeating timeouts are deliberately NOT re-armed here. They are
+                // re-armed on the JS thread once the callback has actually run, so
+                // that at most one invocation of a given interval is ever queued.
+                // Re-arming here instead would let this thread -- which never waits
+                // while a due timeout exists -- spin and enqueue callbacks far
+                // faster than the JS thread can drain them. The resulting unbounded
+                // backlog starves every other item on the JS dispatch queue: other
+                // timers, and native async completions such as shader compilation.
+                CallFunction(id, sequence);
             }
 
             while (!m_shutdown && m_timeMap.empty())
@@ -167,31 +176,71 @@ namespace Babylon::Polyfills::Internal
         }
     }
 
-    void TimeoutDispatcher::CallFunction(TimeoutId id)
+    void TimeoutDispatcher::CallFunction(TimeoutId id, uint64_t sequence)
     {
-        m_runtime.Dispatch([id, this](Napi::Env) {
+        m_runtime.Dispatch([id, sequence, this](Napi::Env) {
             std::shared_ptr<Napi::FunctionReference> function{};
+            std::optional<std::chrono::milliseconds> interval{};
+            TimePoint scheduledTime{};
             {
                 std::unique_lock<std::recursive_mutex> lk{m_mutex};
                 const auto it = m_idMap.find(id);
-                if (it != m_idMap.end())
+                if (it == m_idMap.end() || it->second->sequence != sequence)
                 {
-                    const auto repeat = it->second->interval.has_value();
-                    if (repeat)
-                    {
-                        function = it->second->function;
-                    }
-                    else
-                    {
-                        const auto timeout = std::move(m_idMap.extract(id).mapped());
-                        function = std::move(timeout->function);
-                    }
+                    // Cleared before the callback could run, or the id has since
+                    // been reused by an unrelated timeout.
+                    return;
+                }
+
+                interval = it->second->interval;
+                scheduledTime = it->second->time;
+
+                if (interval.has_value())
+                {
+                    function = it->second->function;
+                }
+                else
+                {
+                    const auto timeout = std::move(m_idMap.extract(id).mapped());
+                    function = std::move(timeout->function);
                 }
             }
 
             if (function)
             {
                 function->Call({});
+            }
+
+            if (!interval.has_value())
+            {
+                return;
+            }
+
+            // Re-arm only now that the callback has completed. Anchor the next
+            // deadline to the previous scheduled time so a long-running callback
+            // does not accumulate drift, but never schedule into the past.
+            std::unique_lock<std::recursive_mutex> lk{m_mutex};
+            const auto it = m_idMap.find(id);
+            if (it == m_idMap.end() || it->second->sequence != sequence)
+            {
+                // Cleared from within its own callback.
+                return;
+            }
+
+            const auto now = Now();
+            auto nextTime = scheduledTime + *interval;
+            if (nextTime < now)
+            {
+                nextTime = now;
+            }
+
+            const auto earliestTime = m_timeMap.empty() ? TimePoint::max() : m_timeMap.cbegin()->second->time;
+            it->second->time = nextTime;
+            m_timeMap.insert({nextTime, it->second.get()});
+
+            if (nextTime <= earliestTime)
+            {
+                m_condVariable.notify_one();
             }
         });
     }

--- a/Polyfills/Scheduling/Source/TimeoutDispatcher.h
+++ b/Polyfills/Scheduling/Source/TimeoutDispatcher.h
@@ -33,6 +33,7 @@ namespace Babylon::Polyfills::Internal
         TimeoutId NextTimeoutId();
         void ThreadFunction();
         void CallFunction(TimeoutId id, uint64_t sequence);
+        void Rearm(TimeoutId id, uint64_t sequence, TimePoint scheduledTime, std::chrono::milliseconds interval);
 
         Babylon::JsRuntime& m_runtime;
         std::recursive_mutex m_mutex{};

--- a/Polyfills/Scheduling/Source/TimeoutDispatcher.h
+++ b/Polyfills/Scheduling/Source/TimeoutDispatcher.h
@@ -32,12 +32,13 @@ namespace Babylon::Polyfills::Internal
 
         TimeoutId NextTimeoutId();
         void ThreadFunction();
-        void CallFunction(TimeoutId id);
+        void CallFunction(TimeoutId id, uint64_t sequence);
 
         Babylon::JsRuntime& m_runtime;
         std::recursive_mutex m_mutex{};
         std::condition_variable_any m_condVariable{};
         TimeoutId m_lastTimeoutId{0};
+        uint64_t m_lastSequence{0};
         std::unordered_map<TimeoutId, std::unique_ptr<Timeout>> m_idMap;
         std::multimap<TimePoint, Timeout*> m_timeMap;
         std::atomic<bool> m_shutdown{false};

--- a/Tests/UnitTests/Scripts/tests.ts
+++ b/Tests/UnitTests/Scripts/tests.ts
@@ -614,6 +614,52 @@ describe("setInterval", function () {
             }
         }, 10);
     });
+
+    it("should not starve other queued work when the interval has no delay", function (done) {
+        // Regression test: a repeating timeout used to be re-armed on the timer
+        // thread immediately, before its callback had run on the JS thread. With a
+        // zero delay that produced an unbounded backlog of queued callbacks which
+        // starved every other item on the JS dispatch queue, so this setTimeout
+        // would never fire.
+        let finished = false;
+        const intervalId = setInterval(() => { });
+
+        const timeoutId = setTimeout(() => {
+            finished = true;
+            clearInterval(intervalId);
+            done();
+        }, 100);
+
+        setTimeout(() => {
+            if (!finished) {
+                clearInterval(intervalId);
+                clearTimeout(timeoutId);
+                done(new Error("setTimeout was starved by a zero delay setInterval"));
+            }
+        }, 2000);
+    });
+
+    it("should stop when cleared from within its own callback", function (done) {
+        // Exercises the re-arm path: a repeating timeout is now re-armed only
+        // after its callback returns, so a clear from inside the callback must
+        // win and no further ticks may occur.
+        let ticks = 0;
+        let id = 0;
+        id = setInterval(() => {
+            ticks++;
+            clearInterval(id);
+        }, 10);
+
+        setTimeout(() => {
+            try {
+                expect(ticks).to.equal(1);
+                done();
+            }
+            catch (e) {
+                done(e);
+            }
+        }, 200);
+    });
 });
 
 describe("clearInterval", function () {

--- a/Tests/UnitTests/Shared/Shared.cpp
+++ b/Tests/UnitTests/Shared/Shared.cpp
@@ -111,6 +111,60 @@ TEST(JavaScript, All)
     EXPECT_EQ(exitCode, 0);
 }
 
+// The unit test host's UnhandledExceptionHandler fails the whole JavaScript
+// suite, so a throwing timer callback cannot be exercised from tests.ts. This
+// covers it natively instead.
+TEST(Scheduling, IntervalSurvivesThrowingCallback)
+{
+    // Regression: repeating timeouts are re-armed after their callback returns
+    // rather than before it runs, so an exception escaping a tick must not
+    // silently stop the interval. Browsers keep the interval running and report
+    // the error, and that is also what this dispatcher did previously.
+    std::promise<int32_t> tickCountPromise;
+    std::atomic<int32_t> unhandledErrorCount{0};
+
+    Babylon::AppRuntime::Options options{};
+    options.UnhandledExceptionHandler = [&unhandledErrorCount](const Napi::Error&) {
+        ++unhandledErrorCount;
+    };
+
+    Babylon::AppRuntime runtime{options};
+
+    runtime.Dispatch([&tickCountPromise](Napi::Env env) {
+        Babylon::Polyfills::Scheduling::Initialize(env);
+
+        auto reportTicks = Napi::Function::New(
+            env, [&tickCountPromise](const Napi::CallbackInfo& info) {
+                tickCountPromise.set_value(info[0].As<Napi::Number>().Int32Value());
+            },
+            "reportTicks");
+        env.Global().Set("reportTicks", reportTicks);
+    });
+
+    Babylon::ScriptLoader loader{runtime};
+    loader.Eval(R"(
+        var ticks = 0;
+        var id = setInterval(function () {
+            ticks++;
+            if (ticks === 3) {
+                clearInterval(id);
+                reportTicks(ticks);
+                return;
+            }
+            throw new Error('tick failed');
+        }, 1);
+    )",
+        "");
+
+    auto tickCountFuture{tickCountPromise.get_future()};
+    ASSERT_EQ(tickCountFuture.wait_for(std::chrono::seconds(10)), std::future_status::ready)
+        << "the interval stopped after a tick threw";
+    EXPECT_EQ(tickCountFuture.get(), 3);
+
+    // The first two ticks threw, and those errors must still be surfaced.
+    EXPECT_EQ(unhandledErrorCount.load(), 2);
+}
+
 TEST(Console, Log)
 {
     Babylon::AppRuntime runtime{};


### PR DESCRIPTION
## Problem

`TimeoutDispatcher::ThreadFunction` re-arms a repeating timeout **on the timer thread, immediately, before its callback has run on the JS thread**:

```cpp
const auto id = m_timeMap.begin()->second->id;
m_timeMap.erase(m_timeMap.begin());
const auto repeat = m_idMap[id]->interval.has_value();
if (repeat)
{
    const auto timeout = std::move(m_idMap.extract(id).mapped());
    DispatchImpl(std::move(timeout->function), *timeout->interval, true, timeout->id);
}
CallFunction(id);   // -> m_runtime.Dispatch(...), i.e. enqueue onto the JS thread
```

With `delay == 0` the re-inserted entry gets `time = Now()`, which is always already due, so the timer thread's `wait_until` never blocks. The thread spins, enqueueing callbacks onto the JS dispatch queue far faster than the JS thread can drain them. That queue is unbounded, so it grows without limit and **every other item on it is starved arbitrarily long** — other timers, and native async completions posted through `JsRuntimeScheduler`.

This is easy to hit by accident. `setInterval(fn)` with no delay argument produces a delay of `0`, and driving a render loop that way is a common pattern.

Reproducing with no framework involved at all — a 0-delay `setInterval` and a `setTimeout(…, 100)` racing each other:

| | ticks | `setTimeout(100)` fired | elapsed |
|---|---|---|---|
| before | 2000 | **no** | 759ms |
| after | 52 | yes, at 111ms | 114ms |

The callback was never lost, only buried: if the interval is stopped with `clearInterval`, the overdue `setTimeout` fires ~40ms later — 2.4s late.

### Downstream impact

In Babylon Native this made `NativeEngine::CreateProgramAsync`'s shader-compile continuation (dispatched via `JsRuntimeScheduler`) never arrive, so effects stayed `isReady === false` with an **empty** `compilationError`, scene readiness callbacks never fired, and the app hung silently with no error. See BabylonJS/BabylonNative#1814.

The signature that isolates it: an identical scene reaches ready in ~13 ticks when driven by `engine.runRenderLoop`, and never when driven by `setInterval` + `beginFrame`/`render`/`endFrame`. The frame driver is the only variable.

## Fix

Re-arm a repeating timeout **on the JS thread, after its callback has actually returned**, so an interval can have at most one invocation pending at a time — matching browser behaviour.

Details worth calling out:

- **Cadence is preserved.** The next deadline is anchored to the *previous scheduled time* (`scheduledTime + interval`), not the completion time, so a slow callback does not make the interval drift. It is clamped to not be in the past. The existing test asserting `elapsed >= tickCount * 10` for a 10ms interval still passes.
- **Id reuse is handled.** A monotonic `sequence` on `Timeout` distinguishes a timeout from a later one that happens to reuse the same id, so an in-flight callback can never re-arm its replacement, and a `clearInterval` issued from inside a callback is honoured.
- **The condition variable is notified on re-arm.** While a lone interval is in flight `m_timeMap` is empty, so the timer thread is parked in `m_condVariable.wait`.
- **`Clear()` stays correct.** While in flight the entry is absent from `m_timeMap`, so its `equal_range` finds nothing and it simply erases from `m_idMap`; the re-arm check then skips. Re-arm updates `timeout->time` before re-inserting, which `Clear()` matches on.
- **Fixes a latent null dereference.** The old code read `m_idMap[id]->interval` with `operator[]`, which default-constructs a null `unique_ptr` when the id is absent and then dereferences it.
- **A throwing tick does not stop the interval.** Since `NAPI_CPP_EXCEPTIONS` is enabled whenever the compiler has exceptions on, `function->Call` throws a C++ `Napi::Error`. Re-arming after the callback means that exception would unwind past the re-arm, so the interval is re-armed from a `catch` and the error is then re-raised via `ThrowAsJavaScriptException()` — leaving `JsRuntime::Dispatch`'s existing pending-exception handling untouched. Browsers behave the same way, as did this dispatcher before the change.

Zero-delay intervals still run at full speed — they just no longer build a backlog. After the fix a 0-delay interval reached **38,357 ticks** in the 100ms before the competing `setTimeout` fired.

## Tests

Two tests added to the `setInterval` suite in `Tests/UnitTests/Scripts/tests.ts`:

- `should not starve other queued work when the interval has no delay` — the regression test.
- `should stop when cleared from within its own callback` — covers the new re-arm path.

One native test added to `Tests/UnitTests/Shared/Shared.cpp`:

- `Scheduling.IntervalSurvivesThrowingCallback` — an interval that throws on the first two ticks must still reach the third, and both errors must still reach `UnhandledExceptionHandler`. This one has to be native, because the unit test host's `UnhandledExceptionHandler` sets the exit code to -1 and so a throwing timer in `tests.ts` would fail the entire JavaScript suite.

**218 JavaScript tests + 7 native tests passing, 0 failing.**

Both regression tests were negative-controlled by reverting only the corresponding production change and keeping the test:

| Test | Without the fix |
|---|---|
| `should not starve other queued work…` | Suite **hangs permanently** and must be killed. Mocha's own timeout is itself a `setTimeout`, so it cannot fire either — a fair illustration of how total the starvation is. |
| `Scheduling.IntervalSurvivesThrowingCallback` | **Fails** after a 10s timeout: `the interval stopped after a tick threw`. |

Also validated against Babylon Native (BabylonNative#1805 branch, 301-test Playground validation suite):

- **301/301 passing**, unchanged, no timing regressions.
- The gizmo readiness matrix {`setInterval`, `runRenderLoop`} × {`parallelShaderCompile` on, off} goes from 2 of 4 cells hanging to **4 of 4 ready**.
- Validation test idx 170 (`Nested BBG`), previously an unbounded hang, now **passes in 2s**.

