### PR TITLE
Build the Windows and UWP CI jobs with Visual Studio 2026

### DIFF
--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2022
+    # See build-win32.yml for why the image label is pinned explicitly.
+    runs-on: windows-2025-vs2026
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/build-win32.yml
+++ b/.github/workflows/build-win32.yml
@@ -12,9 +12,13 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2022
+    # Explicit image label rather than `windows-latest` or `windows-2025`: those
+    # resolve to Windows Server 2025 but their Visual Studio version is not fixed
+    # (actions/runner-images#14004, #14140), and a run whose jobs land on
+    # different images is exactly the kind of failure CI should not have.
+    runs-on: windows-2025-vs2026
     # Hermes pulls in a large LLVH/Boost.Context/BCGen chain through
-    # `hermesvm_a`; on `windows-2022` the full configure+build comfortably
+    # `hermesvm_a`; the full configure+build comfortably
     # exceeds the standard 15-minute window.  Keep other engines snappy.
     timeout-minutes: ${{ inputs.js-engine == 'Hermes' && 60 || 15 }}
     steps:


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

## Context

Both Windows workflows were the last pins on `windows-2022` while macOS already runs `macos-26`, so the Windows toolchain was the one place CI could not see compiler drift coming. Opened as a draft to get real CI signal across every engine and both UWP architectures.

## Worth a look

- The label is pinned to `windows-2025-vs2026` rather than `windows-latest` or `windows-2025`. Those resolve to Windows Server 2025 but not to a fixed Visual Studio version: [actions/runner-images#14004](https://github.com/actions/runner-images/issues/14004) reports the `windows-2025` label serving the VS2026 image, and [#14140](https://github.com/actions/runner-images/issues/14140) reports two jobs in one run landing on different images and breaking MSVC LTCG linking.
- This drops VS2022 coverage rather than adding a second matrix leg, which would double the Windows job count.
- Verified locally before pushing: `main` at `9271f13b` configures and builds clean with VS2026 (MSVC 14.51.36231) for `-A x64 -D NAPI_JAVASCRIPT_ENGINE=JSI`, RelWithDebInfo, with `TreatWarningAsError` on for the targets that pull in GSL. The other engines and both UWP architectures are what this PR is for.
- Local VS2026 is `18.7.12002.237`; the runner image ships `18.8.12023.21`.
