### PR TITLE
QuickJS: report success from the napi_throw family

### DIFF
--- a/Core/Node-API/Source/js_native_api_quickjs.cc
+++ b/Core/Node-API/Source/js_native_api_quickjs.cc
@@ -1586,7 +1586,14 @@ napi_status napi_throw(napi_env env, napi_value error) {
   JSContext* targetCtx = env->current_context ? env->current_context : env->context;
   JS_Throw(targetCtx, JS_DupValue(targetCtx, jsError));
   
-  return napi_set_last_error(env, napi_pending_exception);
+  // Returning napi_pending_exception here would report that the throw itself
+  // failed. node-addon-api's Error::ThrowAsJavaScriptException reacts to that by
+  // re-throwing `Error::New(env)`, which clears the exception it just set and
+  // lets the C++ exception escape the callback wrapper. The escaped error is
+  // then stringified by ExternalCallback::Callback after its handle scope is
+  // gone, which reads freed memory.
+  napi_clear_last_error(env);
+  return napi_ok;
 }
 
 // Throw error
@@ -1602,7 +1609,8 @@ napi_status napi_throw_error(napi_env env, const char* code, const char* msg) {
   }
 
   JS_Throw(env->context, error);
-  return napi_set_last_error(env, napi_pending_exception);
+  napi_clear_last_error(env);
+  return napi_ok;
 }
 
 // Throw type error
@@ -1610,7 +1618,8 @@ napi_status napi_throw_type_error(napi_env env, const char* code, const char* ms
   CHECK_ENV(env);
 
   JS_ThrowTypeError(env->context, "%s", msg ? msg : "");
-  return napi_set_last_error(env, napi_pending_exception);
+  napi_clear_last_error(env);
+  return napi_ok;
 }
 
 // Throw range error
@@ -1618,7 +1627,8 @@ napi_status napi_throw_range_error(napi_env env, const char* code, const char* m
   CHECK_ENV(env);
 
   JS_ThrowRangeError(env->context, "%s", msg ? msg : "");
-  return napi_set_last_error(env, napi_pending_exception);
+  napi_clear_last_error(env);
+  return napi_ok;
 }
 
 // Create error

--- a/Tests/UnitTests/Scripts/tests.ts
+++ b/Tests/UnitTests/Scripts/tests.ts
@@ -1359,6 +1359,26 @@ describe("URLSearchParams", function () {
         expect(() => paramsSet.set()).to.throw();
     });
 
+    it("should preserve the type and message of an error thrown from native code", function () {
+        // A native throw must reach JS unchanged. When napi_throw reported failure, the
+        // error was replaced by an InternalError reading "Uncaught C++ exception: ...",
+        // built by stringifying an error whose handle scope had already closed.
+        let caught: any;
+        try {
+            // @ts-expect-error
+            paramsSet.set();
+        } catch (e) {
+            caught = e;
+        }
+        expect(caught).to.be.an.instanceOf(Error);
+        expect(caught.name).to.equal("Error");
+        // Not an equality check: the JSI backend prefixes "Exception in HostFunction: ".
+        expect(caught.message).to.contain(
+            "Failed to execute 'set' on 'URLSearchParams': 2 arguments required, but only 0 present"
+        );
+        expect(caught.message).to.not.contain("Uncaught C++ exception");
+    });
+
     it("should add a number and retrieve it as a string from searchParams", function () {
         // Set Number
         paramsSet.set("foo", 400 as any);


### PR DESCRIPTION
### Problem

`napi_throw`, `napi_throw_error`, `napi_throw_type_error` and `napi_throw_range_error` returned `napi_pending_exception` after successfully scheduling the throw.

In Node-API that status means *"this call failed because an exception was already pending"*, not *"a throw is now pending"*. The upstream implementation returns `napi_clear_last_error(env)` (i.e. `napi_ok`).

Because the QuickJS port reported failure, `Error::ThrowAsJavaScriptException` in `napi-inl.h` took its failure branch on **every** native throw:

```cpp
napi_status status = napi_throw(_env, Value());
#ifdef NAPI_CPP_EXCEPTIONS
    if (status != napi_ok) {
      throw Error::New(_env);   // consumes the exception that was just set
    }
#endif
```

`Error::New(env)` calls `napi_get_and_clear_last_exception`, so the pending JS exception is discarded and a fresh C++ exception is thrown out of `details::WrapCallback`. `ExternalCallback::Callback` then catches it, observes `!JS_HasException(ctx)`, and rebuilds the error from `e.what()`.

By that point the `HandleScope` opened by `ThrowAsJavaScriptException` has been destroyed during unwinding, so stringifying the message reads freed memory.

### Impact

Two symptoms, both of which reproduce today:

1. **Wrong error surfaced to JS.** The real error is replaced by `InternalError: Uncaught C++ exception: <message>`. Every native throw on QuickJS is affected, so `err.name` and `err instanceof TypeError` are wrong throughout.
2. **Use-after-free.** On Linux this segfaults. Backtrace from a BabylonNative CI core dump:

```
#0  js_dup                       quickjs.c:1628          <-- SIGSEGV
#1  js_force_tostring            quickjs.c:4813
#3  JS_ToCStringLen
#4  napi_get_value_string_utf8   js_native_api_quickjs.cc:696
#5  Napi::String::Utf8Value      napi-inl.h:1118
#7  Napi::Error::Message         napi-inl.h:3087
#8  Napi::Error::what            napi-inl.h:3157
#9  ExternalCallback::Callback   js_native_api_quickjs.cc:164
```

The `JSValue` being stringified carries `JS_TAG_STRING` with an unaligned, freed pointer.

I instrumented the `catch` in `ExternalCallback::Callback` in a BabylonNative QuickJS build and confirmed that **all ~50 native throws** in that test run escaped `WrapCallback` with `hasExc=0`. After this change the count is 0.

### Fix

Return `napi_ok` from the four throw entry points, matching upstream. The exception stays pending, `WrapCallback` returns normally, and the fragile `e.what()` fallback is never entered.

### Test

Added a strict assertion to the existing `URLSearchParams.set()` arity throw, checking the error type and exact message rather than a substring. The pre-existing `.to.throw()` test could not catch this, because `"Uncaught C++ exception: <msg>"` still *contains* the expected substring.

Verified on Linux QuickJS (RelWithDebInfo):

| | result |
|---|---|
| without the C++ change | `expected 'InternalError' to equal 'Error'` — 212 passing, **1 failing** |
| with the C++ change | **213 passing**, 10/10 gtest |

Also verified in a BabylonNative QuickJS build on Windows: 21/21 gtest, 49 JS assertions, exit 0, and zero escapes from `WrapCallback`.