### PR TITLE
Fix V8 N-API leaking every promise ever created

### DIFF
--- a/Core/Node-API/Source/js_native_api_v8_internals.h
+++ b/Core/Node-API/Source/js_native_api_v8_internals.h
@@ -50,7 +50,7 @@ inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
 namespace v8impl {
 
 template <typename T>
-using Persistent = v8::Persistent<T>;
+using Persistent = v8::Global<T>;
 
 class PersistentToLocal {
 public:


### PR DESCRIPTION
## Problem

`v8impl::Persistent<T>` was aliased to `v8::Persistent<T>`, whose default traits set
`kResetInDestructor = false` — the destructor does not dispose the global handle.

`ConcludeDeferred()` (behind `napi_resolve_deferred` / `napi_reject_deferred`) relies on
that destructor:

```cpp
v8impl::Persistent<v8::Value>* deferred_ref = NodePersistentFromJsDeferred(deferred);
...
delete deferred_ref;
```

So the `delete` frees the wrapper but leaks the handle, pinning every promise created via
`napi_create_promise` — and everything its settled value retains — for the life of the
isolate. `napi_env__::context_persistent` leaks the same way. `v8impl::Reference` is
unaffected; it calls `persistent_.Reset()` explicitly.

## Fix

Alias `v8::Global<T>`, which always resets in its destructor. This is what upstream
Node.js uses in
[`src/js_native_api_v8_internals.h`](https://github.com/nodejs/node/blob/main/src/js_native_api_v8_internals.h);
the divergence came from vendoring, where the original `node::Persistent<T>` (a
`v8::Persistent` with `kResetInDestructor = true`) was swapped for the plain V8 type.

`v8::Global` is move-only like the non-copyable `v8::Persistent` it replaces, and every
other member used (`Reset`, `SetWeak`, `ClearWeak`, `IsEmpty`, `Local::New`) lives on
`v8::PersistentBase`, so no call sites change.

## Testing

Static finding from the source, the V8 headers, and upstream parity; no measured
before/after attached. To confirm at runtime, run a long-lived host that settles many
promises (e.g. an image decode returning one promise per image) and watch external
memory / global handle count. Happy to add that before merging.
